### PR TITLE
Fix typo in generated menhir_extra.mly.

### DIFF
--- a/menhir/menhir_library_extra.mly
+++ b/menhir/menhir_library_extra.mly
@@ -56,7 +56,7 @@
 
 %public %inline tuple5(X1, X2, X3, X4, X5):
   x1 = X1; x2 = X2; x3 = X3; x4 = X4; x5 = X5
-    { (x1, x2, x3, x4, x5, x6) }
+    { (x1, x2, x3, x4, x5) }
 
 %public %inline tuple6(X1, X2, X3, X4, X5, X6):
   x1 = X1; x2 = X2; x3 = X3; x4 = X4; x5 = X5; x6 = X6

--- a/ott.opam
+++ b/ott.opam
@@ -26,6 +26,7 @@ run-test: [
   [make "-C" "tests/menhir_tests/test10menhir"]
   [make "-C" "tests/menhir_tests/test10menhir_with_aux_args"]
   [make "-C" "tests/menhir_tests/test10menhir_with_aux_rules"]
+  [make "-C" "tests/menhir_tests/test_case_collision"]
 ]
 dev-repo: "git+https://github.com/ott-lang/ott.git"
 synopsis: "A tool for writing definitions of programming languages and calculi"

--- a/regression/regression.otl
+++ b/regression/regression.otl
@@ -107,3 +107,14 @@ sys-purercdsub : ../examples/tapl/common.ott ../examples/tapl/common_typing.ott 
 ../tests/test_rocq_keywords.ott
 ../tests/test_cr_metahoms.ott
 ../tests/test_ordering_1.ott
+../tests/test_grammar_embed_1.ott
+../tests/test_grammar_embed_2.ott
+../tests/test_grammar_embed_3.ott
+../tests/test_grammar_embed_4.ott
+../tests/test_grammar_embed_leading.ott
+../tests/test_grammar_embed_phantom_only.ott
+../tests/test_grammar_embed_phantom_first.ott
+../tests/test_grammar_embed_grouped.ott
+../tests/test_grammar_embed_ocaml_rename.ott
+../tests/test_grammar_embed_quotient.ott
+../tests/test_grammar_embed_tex_interleave.ott

--- a/src/auxl.ml
+++ b/src/auxl.ml
@@ -1175,8 +1175,8 @@ and rename_freevar map fv =
     fv_that = rename_nt_or_mv_root map fv.fv_that; }
 
 and rename_parsing_annotations map pas =
-  { pa_data = List.map (fun (ntr1,pa_type,ntr2,l)-> 
-      (rename_nontermroot map ntr1,pa_type,rename_nontermroot map ntr2,l)) pas.pa_data }
+  { pa_data = List.map (fun (pn1,pa_type,pn2,l) ->
+      (rename_prodname map pn1, pa_type, rename_prodname map pn2, l)) pas.pa_data }
 
 and rename_dependencies map xddep =
   { xd_dep_ts = List.map (List.map (rename_nt_or_mv_root map)) xddep.xd_dep_ts;

--- a/src/embed_pp.ml
+++ b/src/embed_pp.ml
@@ -35,26 +35,39 @@ open Types;;
 
 let rec embed_strings res el = match el with
   | [] -> res
-  | Embed_string (l,s) :: el ->
+  | Embed_string (_,s) :: el ->
       embed_strings (List.rev_append (Str.split (Str.regexp "[ \t]+") s) res) el
   | Embed_inner _ :: el -> embed_strings res el
 
-let rec pp_embeds fd m xd lookup el =
-  List.iter (pp_embedmorphism fd m xd lookup) el
+let apply_embed_side_effect m _xd _lookup (_l,hn,es) =
+  match (m,hn) with
+  | (Coq co, "coq-lib") | (Coq co, "rocq-lib") ->
+      let x = co.coq_library in
+      x := (fst !x, embed_strings (snd !x) es)
+  | (Isa io, "isa-lib") ->
+      let x = io.isa_library in
+      x := (fst !x, embed_strings (snd !x) es)
+  | _ -> ()
 
-and pp_embedmorphism fd m xd lookup (l,hn,es) =
+let apply_embeds_side_effects m xd lookup el =
+  List.iter (apply_embed_side_effect m xd lookup) el
+
+let rec pp_embeds_with write m xd lookup el =
+  List.iter (pp_embedmorphism_with write m xd lookup) el
+
+and pp_embedmorphism_with write m xd lookup (l,hn,es) =
   let pp_locs = if !Global_option.output_source_locations >=2 then Grammar_pp.pp_source_location m l else "" in
-  output_string fd pp_locs;
+  write pp_locs;
   match (m,hn) with 
   | (Ascii ao, _) -> 
-      output_string fd Grammar_pp.pp_DOUBLELEFTBRACE;
-      output_string fd " ";
-      output_string fd (Grammar_pp.pp_hom_name m xd hn);
-      output_string fd " ";
-      pp_embed_spec fd m xd lookup es;
-      output_string fd " ";
-      output_string fd Grammar_pp.pp_DOUBLERIGHTBRACE;
-      output_string fd "\n";
+      write Grammar_pp.pp_DOUBLELEFTBRACE;
+      write " ";
+      write (Grammar_pp.pp_hom_name m xd hn);
+      write " ";
+      pp_embed_spec_with write m xd lookup es;
+      write " ";
+      write Grammar_pp.pp_DOUBLERIGHTBRACE;
+      write "\n";
   | (Coq _, "coq") | (Coq _, "rocq") 
   | (Isa _, "isa")                       
   | (Hol _, "hol") 
@@ -64,36 +77,44 @@ and pp_embedmorphism fd m xd lookup (l,hn,es) =
   | (Caml _, "ocaml")
   | (Menhir _, "menhir")
   | (Lex _,  "lex") -> 
-      pp_embed_spec fd m xd lookup es;
-      output_string fd "\n"
-  | (Coq co, "coq-lib") | (Coq co, "rocq-lib") -> 
-      let x = co.coq_library in
-      x := (fst !x, embed_strings (snd !x) es)
-  | (Isa io, "isa-lib") -> 
-      let x = io.isa_library in
-      x := (fst !x, embed_strings (snd !x) es)
+      pp_embed_spec_with write m xd lookup es;
+      write "\n"
   | (Coq _, _) | (Isa _, _) | (Hol _,_) | (Lem _,_) | (Twf _,_) | (Tex _,_) | (Caml _,_) | (Lex _, _) | (Menhir _, _) -> ()
 
-and pp_embed_spec fd m xd lookup es = 
-  List.iter (pp_embed_spec_el fd m xd lookup) es
+and pp_embed_spec_with write m xd lookup es = 
+  List.iter (pp_embed_spec_el_with write m xd lookup) es
 
-and pp_embed_spec_el fd m xd lookup ese = 
+and pp_embed_spec_el_with write m xd lookup ese = 
   match m with 
   | Ascii ao -> 
       ( match ese with
-      | Embed_string (l,s) -> output_string fd s
+      | Embed_string (l,s) -> write s
       | Embed_inner (l,s) -> 
-          output_string fd Grammar_pp.pp_DOUBLELEFTBRACKET; 
-          output_string fd s;
-          output_string fd Grammar_pp.pp_DOUBLERIGHTBRACKET )
+          write Grammar_pp.pp_DOUBLELEFTBRACKET; 
+          write s;
+          write Grammar_pp.pp_DOUBLERIGHTBRACKET )
   | Tex xo when (match ese with Embed_inner (_,"TEX_NAME_PREFIX")->true | _->false) -> 
-      output_string fd xo.ppt_name_prefix
+      write xo.ppt_name_prefix
   | Tex _ | Coq _ | Isa _ | Hol _ | Lem _ | Twf _ | Caml _ | Lex _ | Menhir _ -> 
       ( match ese with
-      | Embed_string (l,s) -> output_string fd s
+      | Embed_string (l,s) -> write s
 
       | Embed_inner (l,s) -> (* "<<<<<<"^ s^">>>>>" )  *)
           (* not taking account of possible dot forms shared over different terms *)
           let st = Term_parser.just_one_parse xd lookup "user_syntax" false l s in
           let ((de1,de2) as de,de3,pptbe) = Bounds.bound_extraction m xd l [st]  in
-          output_string fd (Grammar_pp.pp_symterm m xd [] de st))
+          write (Grammar_pp.pp_symterm m xd [] de st))
+
+let pp_embeds fd m xd lookup el =
+  let write s = output_string fd s in
+  pp_embeds_with write m xd lookup el
+
+let pp_embed_spec fd m xd lookup es =
+  let write s = output_string fd s in
+  pp_embed_spec_with write m xd lookup es
+
+let string_of_embeds m xd lookup el =
+  let buf = Buffer.create 256 in
+  let write s = Buffer.add_string buf s in
+  pp_embeds_with write m xd lookup el;
+  Buffer.contents buf

--- a/src/embed_pp.mli
+++ b/src/embed_pp.mli
@@ -37,8 +37,17 @@ val pp_embeds :
   Types.syntaxdefn ->
   Types.made_parser ->
   (Types.loc * Types.hom_name * Types.embed_spec_el list) list -> unit
+val string_of_embeds :
+  Types.pp_mode ->
+  Types.syntaxdefn ->
+  Types.made_parser ->
+  (Types.loc * Types.hom_name * Types.embed_spec_el list) list -> string
+val apply_embeds_side_effects :
+  Types.pp_mode ->
+  Types.syntaxdefn ->
+  Types.made_parser ->
+  (Types.loc * Types.hom_name * Types.embed_spec_el list) list -> unit
 val pp_embed_spec :
   out_channel ->
   Types.pp_mode ->
   Types.syntaxdefn -> Types.made_parser -> Types.embed_spec_el list -> unit
-

--- a/src/global_option.ml
+++ b/src/global_option.ml
@@ -44,3 +44,5 @@ let aux_style_rules = ref true
 let caml_pp_ast_module = ref (None : string option)
 
 let caml_pp_json = ref false
+
+let quiet = ref false

--- a/src/grammar_parser.mly
+++ b/src/grammar_parser.mly
@@ -55,6 +55,12 @@ let parse_error s =
   raise (My_parse_error (Some (mkl ()), "Problem parsing: " ^ s 
 	    ))
 
+let make_rules_items prefix rules =
+  match prefix, rules with
+  | [], rules -> [Raw_item_rs rules]
+  | prefix, [] -> [Raw_item_embed prefix]
+  | prefix, rules -> [Raw_item_embed prefix; Raw_item_rs rules]
+
 (* %token EQUAL             *)
 %}
 
@@ -126,6 +132,12 @@ let parse_error s =
 %type <Types.raw_drule_line_annot> drule_line_annot 
 
 %type <Types.raw_item list> main
+%type <Types.raw_item list> item
+%type <Types.raw_item list> rules
+%type <Types.raw_embed list> rules_prefix
+%type <Types.raw_rule list> rule_list
+%type <Types.raw_rule> rule_with_embeds
+%type <Types.raw_embed list> rule_trailing_embeds
 
 %type <Types.embed_spec_el list> unfiltered_spec_el_list
 
@@ -137,27 +149,27 @@ main:
    items    { $1 } 
 
 items: 
-   item items                     { $1 :: $2 }
+   item items                     { $1 @ $2 }
  | EOF                            { [] }
 
 item: 
-   metavardefn                    { $1 }
+   metavardefn                    { [$1] }
  | RULES rules                    { $2 } 
- | DEFNCLASS defnclass            { $2 }  
- | FUNDEFNCLASS fundefnclass      { $2 }  
- | SUBRULES subrules              { $2 }  
- | CONTEXTRULES contextrules      { $2 }
- | SUBSTITUTIONS substitutions    { $2 }  
- | FREEVARS freevars              { $2 }  
- | EMBED embed                    { $2 }	
- | PARSING parsing_annotations    { $2 }	
- | HOMS hom_section               { $2 }
- | COQSECTIONBEGIN coq_section_begin { $2 }
- | COQSECTIONEND coq_section_end     { $2 }
- | COQVARIABLE coq_variable          { $2 }
- | ROCQSECTIONBEGIN coq_section_begin { $2 }
- | ROCQSECTIONEND coq_section_end     { $2 }
- | ROCQVARIABLE coq_variable          { $2 }
+ | DEFNCLASS defnclass            { [$2] }  
+ | FUNDEFNCLASS fundefnclass      { [$2] }  
+ | SUBRULES subrules              { [$2] }  
+ | CONTEXTRULES contextrules      { [$2] }
+ | SUBSTITUTIONS substitutions    { [$2] }  
+ | FREEVARS freevars              { [$2] }  
+ | EMBED embed                    { [$2] }	
+ | PARSING parsing_annotations    { [$2] }	
+ | HOMS hom_section               { [$2] }
+ | COQSECTIONBEGIN coq_section_begin { [$2] }
+ | COQSECTIONEND coq_section_end     { [$2] }
+ | COQVARIABLE coq_variable          { [$2] }
+ | ROCQSECTIONBEGIN coq_section_begin { [$2] }
+ | ROCQSECTIONEND coq_section_end     { [$2] }
+ | ROCQVARIABLE coq_variable          { [$2] }
 
 metavardefn:
    metavardefn_int   
@@ -303,20 +315,33 @@ element_list:
  | element element_list           { $1 :: $2 }
 
 rules:
-   rule_list
-     { Raw_item_rs $1 }
+   rules_prefix rule_list
+     { make_rules_items $1 $2 }
+
+rules_prefix:
+   /* empty */ %prec DUMMY_ABOVE_EMBED { [] }
+ | EMBED embedmorphism_list rules_prefix { $2 @ $3 }
 
 rule_list:
    /* empty */                    { [] }
- | rule rule_list                 { $1 :: $2 }
+ | rule_with_embeds rule_list     { $1 :: $2 }
 
-rule: 
-   ne_ident_hom_desc_list COLONCOLON STRING CCE homomorphism_list prodlist 
+rule_with_embeds:
+   rule rule_trailing_embeds
+     { { $1 with raw_rule_embeds = $1.raw_rule_embeds @ $2 } }
+
+rule_trailing_embeds:
+   /* empty */ %prec DUMMY_ABOVE_EMBED { [] }
+ | EMBED embedmorphism_list rule_trailing_embeds { $2 @ $3 }
+
+ rule: 
+   ne_ident_hom_desc_list COLONCOLON STRING CCE homomorphism_list prodlist
      { { raw_rule_ntr_name  = fst (List.hd($1));
          raw_rule_ntr_names = $1;
          raw_rule_pn_wrapper = (fst $3);
          raw_rule_ps = $6;
 	 raw_rule_homs = $5;
+         raw_rule_embeds = [];
          raw_rule_categories = ["user"];
          raw_rule_loc = mkl() } }
 
@@ -327,7 +352,7 @@ prod:
          raw_prod_categories = $4;
          raw_prod_es = $2;
 	 raw_prod_homs = $8;
-         raw_prod_bs = $7;
+	 raw_prod_bs = $7;
 	 raw_prod_loc = mkl() } }
 
 prodlist:
@@ -604,5 +629,3 @@ unfiltered_inner:
    /* empty */                         { "" }
  | STRING unfiltered_inner             { (fst $1) ^ $2 }
  | BLANKS unfiltered_inner             { $1 ^ $2 }
-
-

--- a/src/grammar_pp.ml
+++ b/src/grammar_pp.ml
@@ -3112,8 +3112,10 @@ and extract_nonterms_deep_ste_list slil =
   ( match slil with
   | [] -> []
   | Stli_single (_,stel)::tl -> (extract_nonterms_deep stel) @ (extract_nonterms_deep_ste_list tl)
-  | Stli_listform hd::tl -> 
-      Auxl.warning (Some hd.stl_loc) "<<internal: extract_nonterms_deep_ste_list not implemented over listforms>>>";
+  | Stli_listform stlb::tl ->
+      (* Intentionally skip nested listforms: their bound variables are quantified
+         by the inner forall/In structure generated during recursive pretty-printing,
+         and any free variables are already quantified at the rule level via de3. *)
       extract_nonterms_deep_ste_list tl )
   
 and extract_nonterms_deep s =

--- a/src/grammar_pp.ml
+++ b/src/grammar_pp.ml
@@ -336,17 +336,25 @@ and pp_raw_prod p =
   ^ "  " ^ (String.concat " " (List.map pp_raw_homomorphism p.raw_prod_homs))
 
 and pp_raw_rule r =
-  (String.concat " , " (List.map 
-                          (function (n,homs)->
-                            n
-                            ^ String.concat " " (List.map pp_raw_homomorphism homs))
-                          r.raw_rule_ntr_names))
-  ^ " " ^ pp_COLONCOLON ^ " " ^ pp_raw_ident_desc r.raw_rule_pn_wrapper
-  ^ " " ^ pp_CCE 
-  ^ String.concat " " (List.map pp_raw_homomorphism r.raw_rule_homs) 
-  ^ "\n" ^ "  " 
-  ^ String.concat "  " 
-      (List.map (fun rp -> pp_raw_prod rp ^ "\n") r.raw_rule_ps)
+  let pp_embeds embeds =
+    match embeds with
+    | [] -> ""
+    | _ -> String.concat "\n" (List.map pp_raw_embedmorphism embeds) ^ "\n"
+  in
+  let body =
+    (String.concat " , " (List.map 
+                            (function (n,homs)->
+                              n
+                              ^ String.concat " " (List.map pp_raw_homomorphism homs))
+                            r.raw_rule_ntr_names))
+    ^ " " ^ pp_COLONCOLON ^ " " ^ pp_raw_ident_desc r.raw_rule_pn_wrapper
+    ^ " " ^ pp_CCE 
+    ^ String.concat " " (List.map pp_raw_homomorphism r.raw_rule_homs) 
+    ^ "\n" ^ "  " 
+    ^ String.concat "  " 
+        (List.map (fun rp -> pp_raw_prod rp ^ "\n") r.raw_rule_ps)
+  in
+  body ^ pp_embeds r.raw_rule_embeds
 
 and pp_raw_subrule sr =
   pp_raw_ident_desc sr.raw_sr_lower ^ " " ^ pp_LTCOLONCOLON ^ " " 
@@ -392,50 +400,6 @@ and pp_raw_item ri =
   | Raw_item_hs raw_hs -> "TODO: raw hom section"
   | Raw_item_coq_variable _ -> "TODO: coq variable"
   | Raw_item_coq_section _ -> "TODO: coq section"
-        
-
-and pp_raw_syntaxdef xd =
-  String.concat "" (List.map pp_raw_metavardefn xd.raw_sd_mds) 
-  ^ ( match xd.raw_sd_rs with 
-    [] -> "" 
-    | rrs -> pp_RULES ^ "\n" 
-	^ String.concat "\n" (List.map pp_raw_rule xd.raw_sd_rs) )
-  ^ "\n" 
-  ^ ( match xd.raw_sd_srs with 
-    [] -> "" 
-    | srs -> pp_SUBRULES ^ "\n" 
-	^ String.concat "\n" (List.map pp_raw_subrule xd.raw_sd_srs) )
-  ^ "\n" 
-  ^ ( match xd.raw_sd_crs with      
-    [] -> "" 
-    | crs -> pp_CONTEXTRULES ^ "\n" 
-	^ String.concat "\n" (List.map pp_raw_contextrule xd.raw_sd_crs) )
-  ^ "\n" 
-  ^ ( match xd.raw_sd_sbs with 
-    [] -> "" 
-    | sbs -> pp_SUBSTITUTIONS ^ "\n" 
-	^ String.concat "\n" (List.map pp_raw_subst xd.raw_sd_sbs) )
-  ^ "\n"
-  ^ ( match xd.raw_sd_fvs with 
-    [] -> "" 
-    | fvs -> pp_FREEVARS ^ "\n" 
-	^ String.concat "\n" (List.map pp_raw_freevar xd.raw_sd_fvs) )
-  ^ "\n"
-  ^ ( match xd.raw_sd_embed with 
-    [] -> "" 
-    | _ -> 
-	pp_EMBED ^ "\n" 
-	^ String.concat "\n" (List.map pp_raw_embedmorphism xd.raw_sd_embed)
-	^ "\n"  )
-  ^ String.concat "\n" (List.map pp_raw_fun_or_reln_defnclass xd.raw_sd_dcs)
-  ^ "\n"
-  (* ^ ( match xd.raw_sd_embed_postamble with *)
-  (*   [] -> "" *)
-  (*   | _ -> *)
-  (*       pp_EMBED ^ "\n" *)
-  (*       ^ String.concat "\n" (List.map pp_raw_embedmorphism xd.raw_sd_embed_postamble) *)
-  (*       ^ "\n"  ) *)
-  ^ "\n"
 
 and pp_raw_line x = match x with
 | Raw_line (_,s) -> s
@@ -2705,146 +2669,191 @@ and         (* the strip_surrounding_parens is a horrible hack to remove the par
     strip_surrounding_parens s =
   if s.[0]='(' && s.[String.length s -1]=')' then String.sub s 1 (String.length s -2) else s 
 
+and decorate_rule_group string_of_embeds rs body =
+  body ^ String.concat "" (List.map (fun r -> string_of_embeds r.rule_embeds) rs)
 
-and pp_rule_list m xd rs = 
-  (* FZ why rs is a rule list instead of a rulename list? *)
+and ordered_rule_groups m xd rs =
   let ntrs_rs = List.map (fun r -> r.rule_ntr_name) rs in
+  let source_index = Hashtbl.create (max 1 (2 * List.length rs)) in
+  List.iteri
+    (fun idx r -> Hashtbl.replace source_index r.rule_ntr_name idx)
+    rs;
+  let rules_of_group group =
+    let group_ntrs =
+      Auxl.option_map
+        (function
+          | Ntr ntr when List.mem ntr ntrs_rs -> Some ntr
+          | Ntr _ | Mvr _ -> None)
+        group
+    in
+    List.filter (fun r -> List.mem r.rule_ntr_name group_ntrs) rs
+  in
+  let dep_groups =
+    Auxl.option_map
+      (fun group ->
+         let rules_in_group = rules_of_group group in
+         match rules_in_group with
+         | [] -> None
+         | _ ->
+             Some
+               (List.map (fun r -> Ntr r.rule_ntr_name) rules_in_group, rules_in_group))
+      (Auxl.select_dep_ts m xd.xd_dep)
+  in
+  let grouped_members = Hashtbl.create (max 1 (2 * List.length dep_groups)) in
+  List.iter
+    (fun (_, rules_in_group) ->
+       List.iter
+         (fun r -> Hashtbl.replace grouped_members r.rule_ntr_name ())
+         rules_in_group)
+    dep_groups;
+  let singleton_groups =
+    List.filter
+      (fun r -> not (Hashtbl.mem grouped_members r.rule_ntr_name))
+      rs
+  in
+  let rec merge_groups pending groups =
+    match groups with
+    | [] ->
+        List.map (fun r -> ([Ntr r.rule_ntr_name], [r])) pending
+    | (group, rules_in_group) :: groups' ->
+        let min_pos =
+          List.fold_left
+            (fun acc r -> min acc (Hashtbl.find source_index r.rule_ntr_name))
+            max_int
+            rules_in_group
+        in
+        let (before, after) =
+          List.partition
+            (fun r -> Hashtbl.find source_index r.rule_ntr_name < min_pos)
+            pending
+        in
+        List.map (fun r -> ([Ntr r.rule_ntr_name], [r])) before
+        @ (group, rules_in_group) :: merge_groups after groups'
+  in
+  merge_groups singleton_groups dep_groups
 
-  (* print_endline ("** "^(Auxl.hom_name_for_pp_mode m)^" ** pp_rule_list: "^(String.concat " " ntrs_rs));  *)
+and tex_rule_grammar_items ?(string_of_embeds=(fun _ -> "")) m rs =
+  let xo =
+    match m with
+    | Tex xo -> xo
+    | _ -> Auxl.error None "internal: tex_rule_grammar_items on non-tex pp_mode\n"
+  in
+  let tex_item s = if s = "" then None else Some s in
+  let tex_items_of_rule r =
+    let suppressed_ntr = List.mem r.rule_ntr_name xo.ppt_suppressed_ntrs in
+    Auxl.option_map
+      (fun x -> x)
+      [ if suppressed_ntr || (not xo.ppt_show_meta && r.rule_semi_meta)
+        then None
+        else Some (tex_rule_name m r.rule_ntr_name);
+        tex_item (string_of_embeds r.rule_embeds) ]
+  in
+  List.concat (List.map tex_items_of_rule rs)
 
-  let int_rule_list_dep m xd rs td md fd =
-    let rule_groups = 	  
-      let deps = Auxl.select_dep_ts m xd.xd_dep in
-      (* find all dependency groups that mention a rule in rs *)
-      List.filter
-        (fun rg -> List.exists (fun ntr -> List.mem (Ntr ntr) rg) ntrs_rs)
-        deps in
-
-    (* print_endline (String.concat " -- " *)
-    (*                  (List.map (fun rg -> (String.concat " " *)
-    (*                                          (List.map pp_plain_nt_or_mv_root rg))) rule_groups)); *)
-
-    String.concat "" 
-      ( List.map 
-	  ( fun b -> 
-            match b with 
-            (* either there is exactly one ntr in this block, with a hom, *)
-            (* and we generate a type abbreviation *)
-            | [Ntr ntr] 
-              when (None<>Auxl.hom_spec_for_pp_mode m(Auxl.rule_of_ntr xd ntr).rule_homs 
-                      && match m with Isa _ | Coq _ | Hol _ | Lem _ | Caml _ -> true | _ -> false) 
-              ->
-(* PS hack to turn off printing of phantom nonterms which would otherwise turn into type abbreviations.  Please check - maybe this should be before dependency analysis??? *)
-                if (Auxl.rule_of_ntr xd ntr).rule_phantom then "" else 
-		let hs = Auxl.the 
-                    (Auxl.hom_spec_for_pp_mode m (Auxl.rule_of_ntr xd ntr).rule_homs) in
-                ( match m with 
-                | Isa _ -> 
-                    "type_synonym "
-                    ^ "\"" ^ pp_nontermroot_ty m xd ntr ^ "\" = \""
-                    ^ pp_hom_spec m xd hs
-                    ^ "\"\n"
-                | Hol _ -> 
-                    "\nType "
-                    ^ pp_nontermroot_ty m xd ntr ^ " = ``:"
-                    ^ pp_hom_spec m xd hs
-                    ^ "``\n"
-                | Coq _ ->
-                    let homs = (Auxl.rule_of_ntr xd ntr).rule_homs in
-                    let type_name = pp_nontermroot_ty m xd ntr in
-                    let universe =
-                      match Auxl.hom_spec_for_hom_name "rocq-universe" homs with
-                      | Some hs -> pp_hom_spec m xd hs
-                      | None -> "Set"
-                    in
-                    let body = pp_hom_spec m xd hs in
-                    if Auxl.hom_spec_for_hom_name "rocq-notation" homs <> None then
-                      "\nNotation " ^ type_name ^ " := (" ^ body ^ " : " ^ universe ^ ").\n"
-                    else
-                      "\nDefinition " ^ type_name ^ " : " ^ universe ^ " := " ^ body ^ ".\n"
-                | Twf _ -> 
-                    "\n%abbrev "
-                    ^ pp_nontermroot_ty m xd ntr ^ " : type = "
-                    ^ pp_hom_spec m xd hs
-                    ^ ".\n"
-                | Caml _ -> 
-                    "\ntype\n"
-                    ^ pp_nontermroot_ty m xd ntr ^ " = "
-                    ^ pp_hom_spec m xd hs
-                    ^ "\n\n"
-                | Lem _ -> 
-                    "\ntype "
-                    ^ strip_surrounding_parens (pp_nontermroot_ty m xd ntr) ^ " = "
-                    ^ pp_hom_spec m xd hs
-                    ^ "\n\n"
-                | Ascii _ | Tex _ | Lex _ | Menhir _ -> Auxl.errorm m "int_rule_list_dep" )
-            (* or not, in which case we generate an inductive type definition *)
-            | b ->    
-                let b = List.rev b in (* FZ this ensures that the output follows the source order *)
-	        let def_string =
-	          String.concat md 
-		    ( Auxl.option_map 
-		        ( fun nm -> 
-		          ( match nm with
-		          | Mvr mvr -> None
-		          | Ntr ntr -> pp_rule m xd (Auxl.rule_of_ntr xd ntr) ))
-		        b ) in
-	        if (String.length def_string) = 0 then ""
-	        else 
-                  let tds = 
-                    td ( Auxl.option_map 
-		         ( fun nm -> 
-		           ( match nm with
-		           | Mvr mvr -> None
-		           | Ntr ntr -> Some (Auxl.rule_of_ntr xd ntr) ))
-		         b ) in
-                      
-                  tds ^ def_string ^ fd ^ "\n")
-	  rule_groups)
+and pp_rule_list ?(string_of_embeds=(fun _ -> "")) m xd lookup rs = 
+  let render_rule_group td md fd (group, rules_in_group) =
+    match group, rules_in_group with
+    | [Ntr ntr], [r]
+      when (None <> Auxl.hom_spec_for_pp_mode m r.rule_homs
+            && match m with Isa _ | Coq _ | Hol _ | Lem _ | Caml _ -> true | _ -> false) ->
+        let body =
+          if r.rule_phantom then ""
+          else
+            let hs = Auxl.the (Auxl.hom_spec_for_pp_mode m r.rule_homs) in
+            match m with
+            | Isa _ ->
+                "type_synonym "
+                ^ "\"" ^ pp_nontermroot_ty m xd ntr ^ "\" = \""
+                ^ pp_hom_spec m xd hs
+                ^ "\"\n"
+            | Hol _ ->
+                "\nType "
+                ^ pp_nontermroot_ty m xd ntr ^ " = ``:"
+                ^ pp_hom_spec m xd hs
+                ^ "``\n"
+            | Coq _ ->
+                let homs = r.rule_homs in
+                let type_name = pp_nontermroot_ty m xd ntr in
+                let universe =
+                  match Auxl.hom_spec_for_hom_name "rocq-universe" homs with
+                  | Some hs -> pp_hom_spec m xd hs
+                  | None -> "Set"
+                in
+                let body = pp_hom_spec m xd hs in
+                if Auxl.hom_spec_for_hom_name "rocq-notation" homs <> None then
+                  "\nNotation " ^ type_name ^ " := (" ^ body ^ " : " ^ universe ^ ").\n"
+                else
+                  "\nDefinition " ^ type_name ^ " : " ^ universe ^ " := " ^ body ^ ".\n"
+            | Twf _ ->
+                "\n%abbrev "
+                ^ pp_nontermroot_ty m xd ntr ^ " : type = "
+                ^ pp_hom_spec m xd hs
+                ^ ".\n"
+            | Caml _ ->
+                "\ntype\n"
+                ^ pp_nontermroot_ty m xd ntr ^ " = "
+                ^ pp_hom_spec m xd hs
+                ^ "\n\n"
+            | Lem _ ->
+                "\ntype "
+                ^ strip_surrounding_parens (pp_nontermroot_ty m xd ntr) ^ " = "
+                ^ pp_hom_spec m xd hs
+                ^ "\n\n"
+            | Ascii _ | Tex _ | Lex _ | Menhir _ -> Auxl.errorm m "pp_rule_list"
+        in
+        decorate_rule_group string_of_embeds [r] body
+    | _, _ ->
+        let def_string =
+          String.concat md (Auxl.option_map (pp_rule m xd) rules_in_group)
+        in
+        let body =
+          if String.length def_string = 0 then ""
+          else td rules_in_group ^ def_string ^ fd ^ "\n"
+        in
+        decorate_rule_group string_of_embeds rules_in_group body
+  in
+  let render_rule_groups td md fd =
+    String.concat ""
+      (List.map (render_rule_group td md fd) (ordered_rule_groups m xd rs))
   in
 
   match m with 
-  | Ascii ao -> 
-      if (Auxl.select_dep_ts m xd.xd_dep) = [] 
-      then String.concat "\n" (Auxl.option_map (pp_rule m xd) rs) ^ "\n" 
-      else int_rule_list_dep m xd rs (fun rs -> "\n") "\n" ""
-  | Isa io ->
-      int_rule_list_dep m xd rs 
+  | Ascii _ -> 
+      let rendered =
+        if (Auxl.select_dep_ts m xd.xd_dep) = []
+        then render_rule_groups (fun _ -> "") "\n" ""
+        else render_rule_groups (fun _ -> "\n") "\n" ""
+      in
+      if rendered = "" then "\n" else rendered
+  | Isa _ ->
+      render_rule_groups
         ( fun rs -> 
           if Auxl.rules_require_nominal m xd rs then "nominal_datatype " else "datatype ")
         "and " ""
-  | Hol ho ->
-      int_rule_list_dep m xd rs (fun rs -> "val _ = Hol_datatype ` \n") ";\n" "`;"
-  | Coq co ->
-      let def = int_rule_list_dep m xd rs (fun rs -> "\nInductive ") "\nwith " "." in
+  | Hol _ ->
+      render_rule_groups (fun _ -> "val _ = Hol_datatype ` \n") ";\n" "`;"
+  | Coq _ ->
+      let def = render_rule_groups (fun _ -> "\nInductive ") "\nwith " "." in
       let coq_equality_code = !pp_internal_coq_buffer in
       pp_internal_coq_buffer := "";
       def ^ coq_equality_code
-  | Twf wo ->
-      int_rule_list_dep m xd rs (fun rs -> "") "\n" ""
-  | Caml oo ->
-      int_rule_list_dep m xd rs (fun rs -> "\ntype \n") "\nand " ""
-  | Lem lo ->
-      int_rule_list_dep m xd rs (fun rs -> "\ntype ") "\nand " ""
-  | Tex xo ->
-      String.concat "\n" (Auxl.option_map (pp_rule m xd) rs) 
-      ^ "\n" 
+  | Twf _ ->
+      render_rule_groups (fun _ -> "") "\n" ""
+  | Caml _ ->
+      render_rule_groups (fun _ -> "\ntype \n") "\nand " ""
+  | Lem _ ->
+      render_rule_groups (fun _ -> "\ntype ") "\nand " ""
+  | Tex _ ->
+      let defs_block = String.concat "\n" (Auxl.option_map (pp_rule m xd) rs) in
+      let grammar_items = tex_rule_grammar_items ~string_of_embeds m rs in
+      defs_block 
       ^ "\\newcommand{"^pp_tex_RULES_NAME m^"}{"
       ^ pp_tex_BEGIN_RULES m
-      ^ String.concat (pp_tex_INTERRULE_NAME m ^"\n" )
-          (Auxl.option_map 
-             (fun r -> 
-               let suppressed_ntr = 
-                 List.mem r.rule_ntr_name xo.ppt_suppressed_ntrs
-               in
-               if suppressed_ntr || (not(xo.ppt_show_meta) && r.rule_semi_meta) then 
-                 None
-               else Some (tex_rule_name m r.rule_ntr_name))
-             rs)
-      ^ (match rs with []-> "" | _ -> pp_tex_AFTERLASTRULE_NAME m)
+      ^ String.concat (pp_tex_INTERRULE_NAME m ^"\n") grammar_items
+      ^ (match grammar_items with []-> "" | _ -> pp_tex_AFTERLASTRULE_NAME m)
       ^ "\n"^pp_tex_END_RULES ^ "}\n\n"
   | Lex _ | Menhir _ ->
-      String.concat "\n" (Auxl.option_map (pp_rule m xd) rs) 
+      render_rule_groups (fun _ -> "") "\n" ""
  
 
 and pp_ascii_subrule m xd sr = 
@@ -2950,12 +2959,12 @@ and pp_ascii_subst m xd subst =
   ^ pp_nt_or_mv_root m xd subst.sb_that^ " "
   ^ pp_homomorphism_list m xd subst.sb_homs 
 
-and pp_syntaxdefn m xd = 
+and pp_syntaxdefn ?(string_of_embeds=(fun _ -> "")) m xd lookup = 
   match m with
   | Ascii ao -> 
       String.concat "\n" (List.map (pp_metavardefn m xd) xd.xd_mds) 
       ^ pp_RULES^"\n"
-      ^ pp_rule_list m xd xd.xd_rs ^ "\n" 
+      ^ pp_rule_list ~string_of_embeds m xd lookup xd.xd_rs ^ "\n" 
       ^ pp_SUBRULES^"\n"
       ^ String.concat "\n" (List.map (pp_ascii_subrule m xd) xd.xd_srs) ^"\n"
       ^ String.concat "\n" (List.map (pp_ascii_contextrule m xd) xd.xd_crs) ^"\n\n"
@@ -2966,13 +2975,13 @@ and pp_syntaxdefn m xd =
         else "")
   | Isa _ | Coq _ | Hol _ | Lem _ | Twf _ | Caml _ ->
       String.concat "" (List.map (pp_metavardefn m xd) xd.xd_mds) 
-      ^ pp_rule_list m xd xd.xd_rs 
+      ^ pp_rule_list ~string_of_embeds m xd lookup xd.xd_rs 
   | Tex _ ->
       "\\newcommand{"^pp_tex_METAVARS_NAME m^"}{\n"
       ^ pp_tex_BEGIN_METAVARS m  (*  "\\[\\begin{array}{l}\n" *)
       ^ String.concat "\n" (List.map (pp_metavardefn m xd) xd.xd_mds) 
       ^ "\n"^pp_tex_END_METAVARS ^"}\n\n"  (*  ^ "\\end{array}\\]\n" *)
-      ^ pp_rule_list m xd xd.xd_rs
+      ^ pp_rule_list ~string_of_embeds m xd lookup xd.xd_rs
   | Lex _ | Menhir _ ->
       "<<TODO>>"
 
@@ -4292,4 +4301,3 @@ let pp_pp_mode m = match m with
   | Caml _ -> "Caml"
   | Lex _  -> "Lex"
   | Menhir _ -> "Menhir"
-

--- a/src/grammar_typecheck.ml
+++ b/src/grammar_typecheck.ml
@@ -143,6 +143,7 @@ let aux_rule (rr:raw_rule) ((before :string list),(after : string list), (l :loc
     raw_rule_pn_wrapper = "";
     raw_rule_ps = [aux_prod];
     raw_rule_homs = List.filter (function (hn,_,_) ->  hn="auxparam") rr.raw_rule_homs;
+    raw_rule_embeds = [];
     raw_rule_categories = ["aux"];
     raw_rule_loc = l }
 
@@ -192,59 +193,70 @@ let auxify_rules (ri :raw_item) : raw_item =
 
 (* auxiliaries ************************************************************* *)
 
-(* TODO: this old-style concat and merge code should (for tidyness) be
-rewritten over the new (raw_item) raw type *)
+type raw_fragments =
+  { mds : raw_metavardefn list;
+    rs : raw_rule list;
+    dcs : raw_fun_or_reln_defnclass list;
+    srs : raw_subrule list;
+    crs : raw_contextrule list;
+    sbs : raw_subst list;
+    fvs : raw_freevar list;
+    embeds : raw_embed list;
+    pas : raw_parsing_annotations list;
+    hss : raw_hom_section list }
 
-let rsd_of_ri ri = match ri with
-| Raw_item_md raw_md ->        { empty_raw_sd with raw_sd_mds=[raw_md] }
-| Raw_item_rs raw_rs ->        { empty_raw_sd with raw_sd_rs=raw_rs }
-| Raw_item_dcs raw_dcs ->      { empty_raw_sd with raw_sd_dcs=[raw_dcs] }
-| Raw_item_srs raw_srs ->      { empty_raw_sd with raw_sd_srs=raw_srs }
-| Raw_item_crs raw_crs ->      { empty_raw_sd with raw_sd_crs=raw_crs }
-| Raw_item_sbs raw_sbs ->      { empty_raw_sd with raw_sd_sbs=raw_sbs }
-| Raw_item_fvs raw_fvs ->      { empty_raw_sd with raw_sd_fvs=raw_fvs }
-| Raw_item_embed raw_embeds -> { empty_raw_sd with raw_sd_embed=raw_embeds }
-| Raw_item_pas raw_pas ->      { empty_raw_sd with raw_sd_pas=raw_pas }
-| Raw_item_hs raw_hs ->        { empty_raw_sd with raw_sd_hss=[raw_hs] }
-| Raw_item_coq_section raw_qs  -> empty_raw_sd   (* no rep for this in old type *)
-| Raw_item_coq_variable raw_qv  -> empty_raw_sd   (* no rep for this in old type *)
+let empty_raw_fragments =
+  { mds = [];
+    rs = [];
+    dcs = [];
+    srs = [];
+    crs = [];
+    sbs = [];
+    fvs = [];
+    embeds = [];
+    pas = [];
+    hss = [] }
 
-let append_rsd rsd rsd' =
-  { raw_sd_mds = rsd.raw_sd_mds @ rsd'.raw_sd_mds;
-    raw_sd_rs  = rsd.raw_sd_rs  @ rsd'.raw_sd_rs;
-    raw_sd_dcs = rsd.raw_sd_dcs @ rsd'.raw_sd_dcs;
-    raw_sd_srs = rsd.raw_sd_srs @ rsd'.raw_sd_srs;
-    raw_sd_crs = rsd.raw_sd_crs @ rsd'.raw_sd_crs;
-    raw_sd_sbs = rsd.raw_sd_sbs @ rsd'.raw_sd_sbs;
-    raw_sd_fvs = rsd.raw_sd_fvs @ rsd'.raw_sd_fvs;
-    raw_sd_embed = rsd.raw_sd_embed @ rsd'.raw_sd_embed;
-    raw_sd_hss = rsd.raw_sd_hss @ rsd'.raw_sd_hss;
-    raw_sd_pas = rsd.raw_sd_pas @ rsd'.raw_sd_pas;
-    raw_sd_loc = dummy_loc }
+let add_raw_item fragments = function
+  | Raw_item_md raw_md -> { fragments with mds = raw_md :: fragments.mds }
+  | Raw_item_rs raw_rs -> { fragments with rs = List.rev_append raw_rs fragments.rs }
+  | Raw_item_dcs raw_dcs -> { fragments with dcs = raw_dcs :: fragments.dcs }
+  | Raw_item_srs raw_srs -> { fragments with srs = List.rev_append raw_srs fragments.srs }
+  | Raw_item_crs raw_crs -> { fragments with crs = List.rev_append raw_crs fragments.crs }
+  | Raw_item_sbs raw_sbs -> { fragments with sbs = List.rev_append raw_sbs fragments.sbs }
+  | Raw_item_fvs raw_fvs -> { fragments with fvs = List.rev_append raw_fvs fragments.fvs }
+  | Raw_item_embed raw_embeds -> { fragments with embeds = List.rev_append raw_embeds fragments.embeds }
+  | Raw_item_pas raw_pas -> { fragments with pas = List.rev_append raw_pas fragments.pas }
+  | Raw_item_hs raw_hs -> { fragments with hss = raw_hs :: fragments.hss }
+  | Raw_item_coq_section _ | Raw_item_coq_variable _ -> fragments
 
-(* let rec rsds_of_ris ris = match ris with *)
-(* | [] -> empty_raw_sd *)
-(* | ri::ris' -> append_rsd (rsd_of_ri ri) (rsds_of_ris ris') *)
+let finish_raw_fragments fragments =
+  { mds = List.rev fragments.mds;
+    rs = List.rev fragments.rs;
+    dcs = List.rev fragments.dcs;
+    srs = List.rev fragments.srs;
+    crs = List.rev fragments.crs;
+    sbs = List.rev fragments.sbs;
+    fvs = List.rev fragments.fvs;
+    embeds = List.rev fragments.embeds;
+    pas = List.rev fragments.pas;
+    hss = List.rev fragments.hss }
 
-let rec concat_language_fragments_per_file (rsds:raw_syntaxdefn list) : raw_syntaxdefn =
-  match rsds with
-  | [] ->
-      empty_raw_sd
-  | rsd0::rsds' ->
-      let rsd_c = concat_language_fragments_per_file  rsds' in
-      append_rsd rsd0 rsd_c
+let fold_raw_items items =
+  finish_raw_fragments
+    (List.fold_left add_raw_item empty_raw_fragments items)
 
-
-let rec concat_language_fragments (rsds:raw_syntaxdefn list) : raw_syntaxdefn =
-  match rsds with
-  | [] ->
-      empty_raw_sd
-  | rsd0::rsds' ->
-      let rsd_c = concat_language_fragments rsds' in
-      append_rsd rsd0 rsd_c
-
-(* let concat_language_fragments_per_file (after_some_defn:bool) (rsds:raw_syntaxdefn list) : raw_syntaxdefn = raise WorkInProgress *)
-(* let concat_language_fragments (rsds:raw_syntaxdefn list) : raw_syntaxdefn = raise WorkInProgress *)
+let pp_raw_fragments fragments =
+  String.concat "" (List.map Grammar_pp.pp_raw_item (List.map (fun md -> Raw_item_md md) fragments.mds))
+  ^ (match fragments.rs with [] -> "" | rs -> Grammar_pp.pp_raw_item (Raw_item_rs rs))
+  ^ String.concat "" (List.map (fun dcs -> Grammar_pp.pp_raw_item (Raw_item_dcs dcs)) fragments.dcs)
+  ^ (match fragments.srs with [] -> "" | srs -> Grammar_pp.pp_raw_item (Raw_item_srs srs))
+  ^ (match fragments.crs with [] -> "" | crs -> Grammar_pp.pp_raw_item (Raw_item_crs crs))
+  ^ (match fragments.sbs with [] -> "" | sbs -> Grammar_pp.pp_raw_item (Raw_item_sbs sbs))
+  ^ (match fragments.fvs with [] -> "" | fvs -> Grammar_pp.pp_raw_item (Raw_item_fvs fvs))
+  ^ (match fragments.embeds with [] -> "" | embeds -> Grammar_pp.pp_raw_item (Raw_item_embed embeds))
+  ^ (match fragments.pas with [] -> "" | pas -> Grammar_pp.pp_raw_item (Raw_item_pas pas))
+  ^ String.concat "" (List.map (fun hs -> Grammar_pp.pp_raw_item (Raw_item_hs hs)) fragments.hss)
 
 
 (* first-draft code to merge language fragments *)
@@ -273,21 +285,18 @@ let collect = (* : ('a -> 'key) -> 'a list -> 'a list list = *)
 (* to merge the structure informations properly, we need to return
 informations about which rules have been merged *)
 
-let merge_raw_rules (rrs:raw_rule list) : raw_rule list * (nontermroot*loc*nontermroot*loc) list =  
-  let merged = ref [] in
+let merge_raw_rules (rrs:raw_rule list) : raw_rule list =
   let collected_rules = collect (function rr -> rr.raw_rule_ntr_name) rrs in
   let append_raw_rule (rr:raw_rule) (rr':raw_rule) : raw_rule =
-    merged := (rr.raw_rule_ntr_name,rr.raw_rule_loc, rr'.raw_rule_ntr_name,rr'.raw_rule_loc)::!merged;
-    { rr with raw_rule_ps = rr.raw_rule_ps @ rr'.raw_rule_ps } in
-  let rec f rrs = match rrs with
-  | [] -> Auxl.int_error "merge_raw_rules"
-  | [rr] -> rr
-  | rr::rr'::rrs -> append_raw_rule rr (f (rr'::rrs)) in
-  let mapped = List.map f collected_rules in
-  (* print_endline "*** merged infos"; *)
-  (* print_endline (String.concat "\n" (List.map (fun (x,xl,y,yl) -> x^":"^(Location.pp_loc xl)^"\n    "^y^":"^(Location.pp_loc yl)) !merged)); *)
-  (* print_endline "*** end merged infos"; *)
-  (mapped,!merged)
+    { rr with
+      raw_rule_ps = rr.raw_rule_ps @ rr'.raw_rule_ps;
+      raw_rule_embeds = rr.raw_rule_embeds @ rr'.raw_rule_embeds } in
+  let rec merge = function
+    | [] -> Auxl.int_error "merge_raw_rules"
+    | [rr] -> rr
+    | rr::rrs -> append_raw_rule rr (merge rrs)
+  in
+  List.map merge collected_rules
 
 let merge_raw_defns (rds:raw_defn list) : raw_defn list =
   let collected_defns = collect (function rd->rd.raw_d_name) rds in
@@ -334,12 +343,29 @@ let merge_raw_fun_or_reln_defnclasses (rfrdcs:raw_fun_or_reln_defnclass list) : 
 
 
 
-let merge_language_fragments (rsd:raw_syntaxdefn) : raw_syntaxdefn =
-  let (merged_raw_rules,_) = merge_raw_rules rsd.raw_sd_rs in (* FZ tasteless *)
-  { rsd with 
-    raw_sd_rs = merged_raw_rules;
-    raw_sd_dcs = merge_raw_fun_or_reln_defnclasses rsd.raw_sd_dcs
+let merge_fragment_contents fragments =
+  { fragments with
+    rs = merge_raw_rules fragments.rs;
+    dcs = merge_raw_fun_or_reln_defnclasses fragments.dcs
   }
+
+let make_raw_rule ?ntr_names ?(pn_wrapper="") ?(ps=[]) ?(homs=[]) ?(categories=[]) ?(loc=dummy_loc) raw_rule_ntr_name =
+  let raw_rule_ntr_names =
+    match ntr_names with
+    | Some raw_rule_ntr_names -> raw_rule_ntr_names
+    | None -> [raw_rule_ntr_name,[]]
+  in
+  { raw_rule_ntr_name;
+    raw_rule_ntr_names;
+    raw_rule_pn_wrapper = pn_wrapper;
+    raw_rule_ps = ps;
+    raw_rule_homs = homs;
+    raw_rule_embeds = [];
+    raw_rule_categories = categories;
+    raw_rule_loc = loc }
+
+let rule_has_visible_output r =
+  not (r.rule_semi_meta && r.rule_embeds = [])
 
 
 (* check that for each pair in the Subrule part of srs that there is
@@ -1455,23 +1481,16 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
 
   debug_ris_per_file "after quotient and aux"  ris_per_file;
 
-  (* rebuild old raw type (rsds) from new raw type (ris) *)
-  let (rsd_per_file:raw_syntaxdefn list list) = List.map (List.map rsd_of_ri) ris_per_file in
-
-  (* TODO: for tidyiness, the following code should be rewritten to
-  use ris directly rather than via the old-type stuff involving rsds;
-  then we can remove the above line *)
-
   let show_inferred_auxfn_typing = false in
   let show_subrule_data = false in
 
   (* 1- collect together the metavariable, grammar and definition items *)
 
-  let rsd_per_file_2 = (List.map (fun rsd_part -> concat_language_fragments_per_file rsd_part) rsd_per_file) in
+  let fragments = fold_raw_items (List.concat ris_per_file) in
 
-  let rsd = concat_language_fragments rsd_per_file_2 in
-
-  let rsd = if merge_fragments then merge_language_fragments rsd else rsd in
+  let fragments =
+    if merge_fragments then merge_fragment_contents fragments else fragments
+  in
 
   (* 2- synthesise additional grammar items from the definitions for 
         the syntax of judgements *)
@@ -1486,13 +1505,13 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
       raw_prod_loc = d.raw_d_loc } in
 
   let lang_rule_of_defnclass (dc:raw_defnclass) : raw_rule =
-    { raw_rule_ntr_name = dc.raw_dc_name;
-      raw_rule_ntr_names = [dc.raw_dc_name,[]];
-      raw_rule_pn_wrapper = dc.raw_dc_wrapper;
-      raw_rule_ps = List.map sd_prod_of_defn dc.raw_dc_defns;
-      raw_rule_homs = [];
-      raw_rule_categories = ["defnclass"];
-      raw_rule_loc = dc.raw_dc_loc } in
+    make_raw_rule
+      ~pn_wrapper:dc.raw_dc_wrapper
+      ~ps:(List.map sd_prod_of_defn dc.raw_dc_defns)
+      ~categories:["defnclass"]
+      ~loc:dc.raw_dc_loc
+      dc.raw_dc_name
+  in
 
   let defn_sd_prod_of_fundefn (fd:raw_fundefn) : raw_prod =
     { raw_prod_name = fd.raw_fd_name;
@@ -1504,20 +1523,23 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
       raw_prod_loc = fd.raw_fd_loc } in
 
   let defn_lang_rule_of_fundefnclass (fdc:raw_fundefnclass) : raw_rule =
-    { raw_rule_ntr_name = fdc.raw_fdc_name;
-      raw_rule_ntr_names = [fdc.raw_fdc_name,[]];
-      raw_rule_pn_wrapper = "fundefn_";
-      raw_rule_ps = List.map defn_sd_prod_of_fundefn fdc.raw_fdc_fundefns;
-      raw_rule_homs = [];
-      raw_rule_categories = ["fundefnclass"];
-      raw_rule_loc = fdc.raw_fdc_loc } in
+    make_raw_rule
+      ~pn_wrapper:"fundefn_"
+      ~ps:(List.map defn_sd_prod_of_fundefn fdc.raw_fdc_fundefns)
+      ~categories:["fundefnclass"]
+      ~loc:fdc.raw_fdc_loc
+      fdc.raw_fdc_name
+  in
 
   let lang_rule_of_fun_or_reln_defnclass (frdc:raw_fun_or_reln_defnclass) : raw_rule =
     match frdc with
     | Raw_FDC fdc -> defn_lang_rule_of_fundefnclass fdc
     | Raw_RDC dc -> lang_rule_of_defnclass dc in
 
-  let add_extra_lang_rules rsd = { rsd with raw_sd_rs = rsd.raw_sd_rs @ List.map lang_rule_of_fun_or_reln_defnclass rsd.raw_sd_dcs } in
+  let add_extra_lang_rules fragments =
+    { fragments with
+      rs = fragments.rs @ List.map lang_rule_of_fun_or_reln_defnclass fragments.dcs }
+  in
 
   let judgement_nontermroots = 
 (*(*    List.flatten (List.map (fun r -> List.map fst r.raw_rule_ntr_names) extra_lang_rules) in*)*)
@@ -1526,7 +1548,7 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
       match frdc with
       | Raw_FDC fdc -> None
       | Raw_RDC dc -> Some dc.raw_dc_name)
-      rsd.raw_sd_dcs in
+      fragments.dcs in
 
 
 
@@ -1566,7 +1588,7 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
       raw_prod_bs = [];
       raw_prod_loc = fd.raw_fd_loc } in
 
-  let add_extra_lang_usage_prods rsd =
+  let add_extra_lang_usage_prods fragments =
     let rec extra_lang_usage_prods (rs:raw_rule list) (frdcs:raw_fun_or_reln_defnclass list)  : raw_fun_or_reln_defnclass list * (nontermroot * raw_prod) list =
       match frdcs with
       | [] -> [],[]
@@ -1590,14 +1612,14 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
                        in
                        (r.raw_rule_ntr_name, usage_sd_prod_of_fundefn fd),
                        {fd with
-                        raw_fd_result_type=r.raw_rule_ntr_name;
+                       raw_fd_result_type=r.raw_rule_ntr_name;
                         raw_fd_pn_wrapper=r.raw_rule_pn_wrapper }
                      )
                      fdc.raw_fdc_fundefns) in
               Raw_FDC {fdc with raw_fdc_fundefns = fds'} :: frdcs'', extra_prods'@extra_prods in
     
     
-    let frdcs',extra_prods = extra_lang_usage_prods rsd.raw_sd_rs rsd.raw_sd_dcs in
+    let frdcs',extra_prods = extra_lang_usage_prods fragments.rs fragments.dcs in
 
     let rs' = 
       List.map
@@ -1605,9 +1627,9 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
           let extra_prods = Auxl.option_map (fun (ntr,rp)->if ntr=r.raw_rule_ntr_name then Some rp else None) extra_prods in
           {r with raw_rule_ps = r.raw_rule_ps @ extra_prods }
         )
-        rsd.raw_sd_rs in
+        fragments.rs in
   
-    { rsd with raw_sd_rs=rs'; raw_sd_dcs=frdcs' } in
+    { fragments with rs = rs'; dcs = frdcs' } in
 
     
 (*     let extra_lang_usage_prods  : (nontermroot * raw_prod) list =  *)
@@ -1649,22 +1671,20 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
     
     if List.exists
 	(fun r -> (String.compare r.raw_rule_ntr_name "formula") = 0) 
-	rsd.raw_sd_rs
+	fragments.rs
     then []
     else
-      [ { raw_rule_ntr_name = "formula";
-	  raw_rule_ntr_names = ["formula",[]];
-	  raw_rule_pn_wrapper = "formula_";
-	  raw_rule_ps = [ { raw_prod_name = "judgement";
-			    raw_prod_flavour = Bar;
-			    raw_prod_categories = [];
-			    raw_prod_es = [Raw_ident (dummy_loc,(dummy_loc,"judgement"))];
-			    raw_prod_homs = [];
-			    raw_prod_bs = [];
-			    raw_prod_loc = dummy_loc } ];
-	raw_rule_homs = [];
-	raw_rule_categories = ["formula"];
-	raw_rule_loc = dummy_loc } ] in
+      [ make_raw_rule
+          ~pn_wrapper:"formula_"
+          ~ps:[ { raw_prod_name = "judgement";
+                  raw_prod_flavour = Bar;
+                  raw_prod_categories = [];
+                  raw_prod_es = [Raw_ident (dummy_loc,(dummy_loc,"judgement"))];
+                  raw_prod_homs = [];
+                  raw_prod_bs = [];
+                  raw_prod_loc = dummy_loc } ]
+          ~categories:["formula"]
+          "formula" ] in
    
   (* 3b- synthesise a grammar of all judgements *)
 
@@ -1678,47 +1698,44 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
       raw_prod_loc = dummy_loc } in
 
   let judgement : raw_rule =
-    { raw_rule_ntr_name = "judgement";
-      raw_rule_ntr_names = ["judgement",[]; (*"J",[]*)];
-      raw_rule_pn_wrapper = "judgement_";
-      raw_rule_ps = List.map prod_of_root judgement_nontermroots;
-      raw_rule_homs = [];
-      raw_rule_categories = ["judgement"];
-      raw_rule_loc = dummy_loc } in
+    make_raw_rule
+      ~ntr_names:["judgement",[]; (*"J",[]*)]
+      ~pn_wrapper:"judgement_"
+      ~ps:(List.map prod_of_root judgement_nontermroots)
+      ~categories:["judgement"]
+      "judgement"
+  in
 
   (* 3c- synthesise a grammar of all user syntax *)
 
   let user_syntax_nontermroots = 
-(*    List.flatten (List.map (fun r -> List.map fst r.raw_rule_ntr_names) rsd.raw_sd_rs) in *)
-    (List.map (fun r -> r.raw_rule_ntr_name) rsd.raw_sd_rs) in
+(*    List.flatten (List.map (fun r -> List.map fst r.raw_rule_ntr_names) fragments.rs) in *)
+    (List.map (fun r -> r.raw_rule_ntr_name) fragments.rs) in
 
   let user_syntax_metavarroots = 
-(*    List.flatten (List.map (fun md -> List.map fst md.raw_mvd_names) rsd.raw_sd_mds) in*)
-    (List.map (fun md -> md.raw_mvd_name) rsd.raw_sd_mds) in
+(*    List.flatten (List.map (fun md -> List.map fst md.raw_mvd_names) fragments.mds) in*)
+    (List.map (fun md -> md.raw_mvd_name) fragments.mds) in
 
   let user_syntax : raw_rule =
-    { raw_rule_ntr_name = "user_syntax";
-      raw_rule_ntr_names = ["user_syntax",[]];
-      raw_rule_pn_wrapper = "user_syntax__";
-      raw_rule_ps = List.map prod_of_root (user_syntax_metavarroots @ user_syntax_nontermroots);
-      raw_rule_homs = [];
-      raw_rule_categories = ["user_syntax"];
-      raw_rule_loc = dummy_loc } in
+    make_raw_rule
+      ~pn_wrapper:"user_syntax__"
+      ~ps:(List.map prod_of_root (user_syntax_metavarroots @ user_syntax_nontermroots))
+      ~categories:["user_syntax"]
+      "user_syntax"
+  in
   
-  let rsd' =      
-    { rsd with    
-      raw_sd_rs = rsd.raw_sd_rs@formula } in   
+  let fragments = { fragments with rs = fragments.rs @ formula } in
 
-  let rsd' = add_extra_lang_usage_prods rsd' in
+  let fragments = add_extra_lang_usage_prods fragments in
 
-  let rsd' = add_extra_lang_rules rsd' in
+  let fragments = add_extra_lang_rules fragments in
 
-  let rsd' =      
-    { rsd' with    
-      raw_sd_rs = rsd'.raw_sd_rs @ [judgement] @ [user_syntax] } in   
+  let fragments =
+    { fragments with rs = fragments.rs @ [judgement] @ [user_syntax] }
+  in
 
   debug ( "\nSynthesised raw language:\n"
-	  ^  Grammar_pp.pp_raw_syntaxdef rsd'^"\n\n" );
+	  ^  pp_raw_fragments fragments ^"\n\n" );
 
   (* 3d- append the homs from any extra hom sections onto the relevant *)
   (* productions and definitions *)
@@ -1731,7 +1748,7 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
              (rhs.raw_hs_wrapper^rhsi.raw_hsi_name,
               (rhsi.raw_hsi_bs,rhsi.raw_hsi_homs))) 
              rhs.raw_hs_hsis)
-         rsd'.raw_sd_hss) in
+         fragments.hss) in
 
   let rec fst_map f (xs,y) = (* (f:'a * 'b -> 'a * 'b) ((xs,y):'a list * 'b) : 'a list * 'b = *)
     match xs with 
@@ -1811,14 +1828,15 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
   let append_homs_fun_or_reln_defnclasss =
     fst_map append_homs_fun_or_reln_defnclass in
 
-  let (raw_sd_rs',rehs') = append_homs_rules (rsd'.raw_sd_rs, collected_extra_homs) in
+  let (raw_rs',rehs') = append_homs_rules (fragments.rs, collected_extra_homs) in
 
-  let (raw_sd_dcs',rehs'') = append_homs_fun_or_reln_defnclasss (rsd'.raw_sd_dcs, rehs') in
+  let (raw_dcs',rehs'') = append_homs_fun_or_reln_defnclasss (fragments.dcs, rehs') in
 
   if rehs'' <> [] then failwith ("hom section contains items for nonexistent production or defn names: "^String.concat ", " (List.map fst rehs'')) (* TODO add location data to that error *);
 
-  let rsd' =       
-    { rsd' with raw_sd_rs = raw_sd_rs'; raw_sd_dcs=raw_sd_dcs' } in   
+  let fragments =
+    { fragments with rs = raw_rs'; dcs = raw_dcs' }
+  in
 
 
 
@@ -1839,7 +1857,7 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
   
   (* make an association list of metavar roots - primary to the synonyms *)
   let mvrs_assoc : (metavarroot * metavarroot list) list =
-    List.map (fun md -> md.raw_mvd_name, (List.map fst md.raw_mvd_names)) rsd'.raw_sd_mds in
+    List.map (fun md -> md.raw_mvd_name, (List.map fst md.raw_mvd_names)) fragments.mds in
   (* and one in the other direction *)
   let mvrs_assoc_op : (metavarroot * metavarroot) list =
     List.concat 
@@ -1853,21 +1871,21 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
 (*  let mvrs_all = 
     List.sort 
       (fun a -> fun b -> compare b a) 
-      (List.concat (List.map (fun md -> (List.map fst md.raw_mvd_names)) rsd'.raw_sd_mds)) in *)
+      (List.concat (List.map (fun md -> (List.map fst md.raw_mvd_names)) fragments.mds)) in *)
   let mvrs_nonindex = 
     List.sort 
       (fun a -> fun b -> compare b a) 
       (List.concat 
          (List.map 
             (fun md -> (List.map fst md.raw_mvd_names)) 
-            (List.filter (function md->not md.raw_mvd_indexvar) rsd'.raw_sd_mds))) in
+            (List.filter (function md->not md.raw_mvd_indexvar) fragments.mds))) in
   let mvrs_index = 
     List.sort 
       (fun a -> fun b -> compare b a) 
       (List.concat 
          (List.map 
             (fun md -> (List.map fst md.raw_mvd_names)) 
-            (List.filter (function md->md.raw_mvd_indexvar) rsd'.raw_sd_mds))) in
+            (List.filter (function md->md.raw_mvd_indexvar) fragments.mds))) in
   
   (* 5- collect together all the primary nonterminal roots *)
 
@@ -1875,7 +1893,7 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
   let ntrs_assoc : (nontermroot * nontermroot list) list =
     List.map 
       (fun rr -> rr.raw_rule_ntr_name, (List.map fst rr.raw_rule_ntr_names)) 
-      rsd'.raw_sd_rs in
+      fragments.rs in
   (* and one in the other direction *)
   let ntrs_assoc_op : (nontermroot * nontermroot) list =
     List.concat 
@@ -1889,14 +1907,14 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
       (function a -> function b -> compare b a) 
       (List.concat (List.map 
 		      (fun rr -> (List.map fst rr.raw_rule_ntr_names)) 
-		      rsd'.raw_sd_rs)) in
+		      fragments.rs)) in
   (* collect together all the nontermroots, primaried, that occur on the left of a <::  *)
   let wrapped_primary_ntr_of_ntr rsr ntr = try
     primary_ntr_of_ntr ntr 
   with
   | Not_found -> ty_error2 rsr.raw_sr_loc ("\""^ntr^"\" in subrule declaration is not a nonterminal root ") "" in
-  let srs_lowers = List.map (fun sr -> (wrapped_primary_ntr_of_ntr sr sr.raw_sr_lower)) rsd'.raw_sd_srs in
-(*  let srs_uppers = List.map (fun sr -> (wrapped_primary_ntr_of_ntr sr.raw_sr_upper)) rsd'.raw_sd_srs in *)
+  let srs_lowers = List.map (fun sr -> (wrapped_primary_ntr_of_ntr sr sr.raw_sr_lower)) fragments.srs in
+(*  let srs_uppers = List.map (fun sr -> (wrapped_primary_ntr_of_ntr sr.raw_sr_upper)) fragments.srs in *)
   
   (* 6- make a preliminary ident_lexer that doesn't know about any terminals *)
 
@@ -1964,6 +1982,7 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
       rule_pn_wrapper = r.raw_rule_pn_wrapper;
       rule_ps = List.map (cd_prod c r.raw_rule_ntr_name r.raw_rule_pn_wrapper targets rule_homs_for_targets) r.raw_rule_ps;
       rule_homs = rule_homs;
+      rule_embeds = cd_embeds c r.raw_rule_embeds;
       rule_meta = 
       ( rule_semi_meta
       || List.mem r.raw_rule_ntr_name srs_lowers
@@ -1975,22 +1994,32 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
 
   (* 9- build a preliminary syntax defn, without dependencies or auxfns *)
 
-  (* embed preamble are those embeds labeled by ___-preamble *)
-  let raw_embed_preamble = 
-    Auxl.option_map
-      (fun (l,hn,he) ->
-         match hn with
-         | "tex-preamble"   -> Some (l,"tex",he)
-         | "tex-wrap-pre"
-         | "tex-wrap-post"  -> Some (l,hn,he)
-         | "coq-preamble"   -> Some (l,"rocq",he)
-         | "rocq-preamble"  -> Some (l,"rocq",he)
-         | "isa-preamble"   -> Some (l,"isa",he)
-         | "hol-preamble"   -> Some (l,"hol",he)
-         | "lem-preamble"   -> Some (l,"lem",he)
-         | "ocaml-preamble" -> Some (l,"ocaml",he)
-         | _                -> None)
-      rsd'.raw_sd_embed in
+  let raw_embed_preamble, raw_embed_whole_file, raw_structure_embeds =
+    let embed_preamble_target = function
+      | "tex-preamble" -> Some "tex"
+      | ("tex-wrap-pre" | "tex-wrap-post") as hn -> Some hn
+      | "coq-preamble" | "rocq-preamble" -> Some "rocq"
+      | "isa-preamble" -> Some "isa"
+      | "hol-preamble" -> Some "hol"
+      | "lem-preamble" -> Some "lem"
+      | "ocaml-preamble" -> Some "ocaml"
+      | _ -> None
+    in
+    let embed_is_whole_file = function
+      | "coq-lib" | "rocq-lib" | "isa-lib" | "isa-import" -> true
+      | _ -> false
+    in
+    List.fold_right
+      (fun ((l,hn,he) as embed) (preamble, whole_file, structure) ->
+         match embed_preamble_target hn with
+         | Some target -> ((l,target,he) :: preamble, whole_file, structure)
+         | None when embed_is_whole_file hn ->
+             (preamble, embed :: whole_file, structure)
+         | None ->
+             (preamble, whole_file, embed :: structure))
+      fragments.embeds
+      ([], [], [])
+  in
 
   (* calculate additional file names that the Isabelle header should include (isa-import) *)
   let raw_isa_imports = 
@@ -2003,11 +2032,11 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
            match hn with
            | "isa-import" -> List.fold_left get_string r he
            | _            -> r) 
-        [] rsd'.raw_sd_embed) in
+        [] raw_embed_whole_file) in
    
   let xd =
-    let srs,srd = cd_subrules c rsd'.raw_sd_srs in
-    let rs = List.map (cd_rule c) rsd'.raw_sd_rs in
+    let srs,srd = cd_subrules c fragments.srs in
+    let rs = List.map (cd_rule c) fragments.rs in
     let all_prod_names = List.flatten (List.map (fun r -> List.map (fun p->p.prod_name) r.rule_ps) rs) in
     { xd_mds = List.map 
 	(fun (mvd:raw_metavardefn) -> 
@@ -2028,19 +2057,19 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
 	      else (try let _ = List.assoc "phantom" mvd_rep in true with Not_found -> false);
 	    mvd_loc = mvd.raw_mvd_loc;
           } ) 
-	rsd'.raw_sd_mds;
+	fragments.mds;
       xd_rs = rs;
       xd_dep = List.map (fun x -> (x,empty_dependencies)) ("ascii"::targets);
       xd_srs = srs;
       xd_srd = srd;
-      xd_crs = List.map (cd_contextrule c) rsd'.raw_sd_crs;
+      xd_crs = List.map (cd_contextrule c) fragments.crs;
       xd_axs = [];  (* this is overridden by something more sensible below *)
-      xd_sbs = List.map (cd_subst c srs) rsd'.raw_sd_sbs;
-      xd_fvs = List.map (cd_freevar c srs) rsd'.raw_sd_fvs;
+      xd_sbs = List.map (cd_subst c srs) fragments.sbs;
+      xd_fvs = List.map (cd_freevar c srs) fragments.fvs;
       xd_embed_preamble = cd_embeds c raw_embed_preamble;
-      xd_embed = cd_embeds c rsd'.raw_sd_embed;
+      xd_embed = cd_embeds c raw_embed_whole_file;
       xd_isa_imports = raw_isa_imports;
-      xd_pas = cd_parsing_annotations all_prod_names rsd'.raw_sd_pas;
+      xd_pas = cd_parsing_annotations all_prod_names fragments.pas;
     } in
 
   (*  - pull the names of defined auxiliary functions, paired with the *)
@@ -2681,7 +2710,10 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
       xd.xd_mds in
   let structure_rs =
     Auxl.option_map
-      (fun r -> if r.rule_semi_meta then None else Some (r.rule_loc, (Struct_rs [r.rule_ntr_name])))
+      (fun r ->
+         if not (rule_has_visible_output r)
+         then None
+         else Some (r.rule_loc, (Struct_rs [r.rule_ntr_name])))
       xd.xd_rs in
   let structure_srs = 
     let candidate = 
@@ -2722,8 +2754,9 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
       (fun fv -> (fv.fv_loc, (Struct_fvs [(fv.fv_name, fv.fv_this, fv.fv_that)])))
       xd.xd_fvs in
   let structure_embed = 
-    let all_embeds = xd.xd_embed_preamble @ xd.xd_embed in
-    List.map (fun (l,m,e) -> (l,Struct_embed (l,m,e))) all_embeds  (* FZ this duplicates a lot of informations...  FIXME *)
+    List.map
+      (fun (l,m,e) -> (l,Struct_embed (l,m,e)))
+      (cd_embeds c raw_structure_embeds)
   in
   let structure_dcs =
     List.map
@@ -2731,7 +2764,7 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
         match dc with
         | Raw_FDC fdc -> (fdc.raw_fdc_loc, Struct_fun_or_defnclass fdc.raw_fdc_name)
         | Raw_RDC rdc -> (rdc.raw_dc_loc, Struct_fun_or_defnclass rdc.raw_dc_name))
-      raw_sd_dcs' in
+      fragments.dcs in
 
   let unsorted_structure =
     structure_mds 
@@ -2867,7 +2900,7 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
   if not(merge_fragments) then check_structure xd structure;
 
   (* 14- the answer *)
-  (xd, structure, rsd'.raw_sd_dcs)
+  (xd, structure, fragments.dcs)
 
 
 let check_with_parser (lookup : made_parser) (xd: syntaxdefn) : unit =
@@ -2892,4 +2925,3 @@ let check_with_parser (lookup : made_parser) (xd: syntaxdefn) : unit =
   in         
   (* for each rule, test all productions *)
   List.iter (fun cr -> ctxrule cr.cr_hole cr.cr_ntr cr.cr_target) xd.xd_crs; 
-

--- a/src/lex_menhir_pp.ml
+++ b/src/lex_menhir_pp.ml
@@ -1237,8 +1237,9 @@ let pp_menhir_precedences fd ts =
 *)
 
 (* output a menhir source file *)
-let pp_menhir_syntaxdefn m sources _(*xd_quotiented*) xd_unquotiented lookup generate_aux_info oi = 
+let pp_menhir_syntaxdefn m sources _(*xd_quotiented*) sd_unquotiented lookup generate_aux_info oi = 
   let yo = match m with Menhir yo -> yo | _ -> raise (Failure "pp_menhir_systemdefn called with bad ppmode") in 
+  let xd_unquotiented = sd_unquotiented.syntax in
   (* Store the syntax definition for use in rule suppression decisions *)
   yo.syntaxdefn <- Some xd_unquotiented;
   match oi with
@@ -1257,7 +1258,12 @@ let pp_menhir_syntaxdefn m sources _(*xd_quotiented*) xd_unquotiented lookup gen
       output_string fd "\n%%\n";
 *)
       output_string fd "\n";
-      Embed_pp.pp_embeds fd m xd_unquotiented lookup xd_unquotiented.xd_embed;
+      Embed_pp.pp_embeds fd m xd_unquotiented lookup
+        (Auxl.option_map
+           (function
+             | (_, Struct_embed embed) -> Some embed
+             | _ -> None)
+           sd_unquotiented.structure);
 
       output_string fd (pp_menhir_start_symbols yo generate_aux_info xd_unquotiented);
       output_string fd "\n\n%%\n\n";
@@ -1312,5 +1318,4 @@ let pp_pp_syntaxdefn m sources xd_quotiented xd_unquotiented xd_quotiented_unaux
                       ^ pp_pp_json_metavar_defns_and_rules yo generate_aux_info xd ts xd.xd_mds xd.xd_rs
                    );
   close_out fd;
-
 

--- a/src/lex_menhir_pp.ml
+++ b/src/lex_menhir_pp.ml
@@ -513,8 +513,44 @@ type element_data = {
   }
 
 let pp_json_key s = "\\\"" ^ s ^ "\\\""
-                  
-let rec element_data_of_element xd ts (allow_lists:bool) (indent_nonterms:bool) (no_json_key : bool) e : element_data = 
+
+let unique_semantic_value_ids semantic_value_ids =
+  let unique_names = Auxl.ensure_unique_names (Auxl.option_map (fun id -> id) semantic_value_ids) in
+  let rec assign semantic_value_ids unique_names =
+    match semantic_value_ids with
+    | [] -> []
+    | None :: semantic_value_ids' ->
+        None :: assign semantic_value_ids' unique_names
+    | Some _ :: semantic_value_ids' ->
+        (match unique_names with
+        | unique_name :: unique_names' ->
+            Some unique_name :: assign semantic_value_ids' unique_names'
+        | [] ->
+            raise (Failure "unique_semantic_value_ids")) in
+  assign semantic_value_ids unique_names
+
+let semantic_value_id_of_element e =
+  match e with
+  | Lang_terminal _ -> None
+  | Lang_nonterm (_,nt) -> Some (menhir_semantic_value_id_of_ntmv nt)
+  | Lang_metavar (_,mv) -> Some (menhir_semantic_value_id_of_ntmv mv)
+  | Lang_list elb -> Some (menhir_semantic_value_id_of_list elb.elb_es)
+  | _ -> raise (Failure "unexpected Lang_ form")
+
+let required_semantic_value_id kind = function
+  | Some id -> id
+  | None -> raise (Failure ("missing semantic value id for " ^ kind))
+
+let pp_pretty_rhs_if_not_suppressed homs rhs =
+  match Auxl.hom_spec_for_hom_name "pp-suppress" homs with
+  | Some _ -> None
+  | None -> Some rhs
+
+let rec element_data_of_elements xd ts (allow_lists:bool) (indent_nonterms:bool) (no_json_key : bool) es =
+  let semantic_value_ids = unique_semantic_value_ids (List.map semantic_value_id_of_element es) in
+  List.map2 (element_data_of_element xd ts allow_lists indent_nonterms no_json_key) semantic_value_ids es
+
+and element_data_of_element xd ts (allow_lists:bool) (indent_nonterms:bool) (no_json_key : bool) semantic_value_id e : element_data = 
 (*string option(*semantic_value_id*) * string(*grammar body*) * string option (*semantic action*) =*)
   match e with
   | Lang_terminal t -> 
@@ -526,7 +562,7 @@ let rec element_data_of_element xd ts (allow_lists:bool) (indent_nonterms:bool) 
         pp_pretty_rhs     = Some ("string \"" ^ String.escaped t ^ "\""); }
 
   | Lang_nonterm (ntr,nt) ->
-      let svi = menhir_semantic_value_id_of_ntmv nt in 
+      let svi = required_semantic_value_id "Lang_nonterm" semantic_value_id in
       (* Check if this nonterminal is suppressed due to subrules *)
       let subrule_opt = 
         try Some (List.find (function sr -> sr.sr_lower = ntr) xd.xd_srs) 
@@ -535,6 +571,9 @@ let rec element_data_of_element xd ts (allow_lists:bool) (indent_nonterms:bool) 
         match subrule_opt with
         | Some sr -> (sr.sr_top, Some ("is_" ^ ntr ^ "_of_" ^ sr.sr_top))
         | None -> (ntr, None) in
+      let actual_rule = Auxl.rule_of_ntr_nonprimary xd actual_ntr in
+      let params = pp_params actual_rule in
+      let pp_arg = params ^ " " ^ svi in
       let actual_semantic_action = 
         match runtime_check with
         | Some check -> Some ("(if " ^ check ^ " " ^ svi ^ " then " ^ svi ^ " else raise Parsing.Parse_error)")
@@ -542,45 +581,39 @@ let rec element_data_of_element xd ts (allow_lists:bool) (indent_nonterms:bool) 
       { semantic_value_id = Some svi;
         grammar_body      = menhir_nonterminal_id_of_ntr actual_ntr;
         semantic_action   = actual_semantic_action;
-        pp_raw_rhs        = Some (pp_pp_raw_name actual_ntr ^ pp_params (Auxl.rule_of_ntr_nonprimary xd actual_ntr) ^ " " ^ svi);
+        pp_raw_rhs        = Some (pp_pp_raw_name actual_ntr ^ pp_arg);
         pp_json_rhs       = Some (
                                 (if no_json_key then
                                   ""
                                 else
                                   "string \"" ^ pp_json_key (Grammar_pp.pp_plain_nonterm nt)  ^ ":\" ^^ ")
-                                ^ pp_pp_json_name actual_ntr ^ pp_params (Auxl.rule_of_ntr_nonprimary xd actual_ntr) ^ " " ^ svi);
-        pp_pretty_rhs     
-          = match Auxl.hom_spec_for_hom_name "pp-suppress" (Auxl.rule_of_ntr_nonprimary xd actual_ntr).rule_homs with 
-          | Some hs ->
-              None
-          | None -> 
-              if indent_nonterms then
-                Some ("nest 2 (" ^ pp_pp_name actual_ntr ^ pp_params (Auxl.rule_of_ntr_nonprimary xd actual_ntr) ^ " " ^ svi ^")")
-              else
-                Some ("" ^ pp_pp_name actual_ntr ^ pp_params (Auxl.rule_of_ntr_nonprimary xd actual_ntr) ^ " " ^ svi ^"";) }
+                                ^ pp_pp_json_name actual_ntr ^ pp_arg);
+        pp_pretty_rhs     =
+          pp_pretty_rhs_if_not_suppressed actual_rule.rule_homs
+            (if indent_nonterms then
+               "nest 2 (" ^ pp_pp_name actual_ntr ^ pp_arg ^")"
+             else
+               pp_pp_name actual_ntr ^ pp_arg) }
 
   | Lang_metavar (mvr,mv) -> (* assuming all metavars map onto string-containing tokens *)
-      let svi = menhir_semantic_value_id_of_ntmv mv in 
+      let svi = required_semantic_value_id "Lang_metavar" semantic_value_id in
+      let mvd = Auxl.mvd_of_mvr_nonprimary xd mvr in
       { semantic_value_id = Some svi;
         grammar_body      = token_of_metavarroot ts mvr;
         semantic_action   = Some svi;
         pp_raw_rhs        = Some (pp_pp_raw_name mvr ^ " " ^ svi);
         pp_json_rhs       = Some ( "string \"" ^ pp_json_key (Grammar_pp.pp_plain_metavar mv) ^ " : \" ^^ " ^ pp_pp_json_name mvr ^ " " ^ svi);
-        pp_pretty_rhs     
-          = match Auxl.hom_spec_for_hom_name "pp-suppress" (Auxl.mvd_of_mvr_nonprimary xd mvr).mvd_rep with 
-          | Some hs ->
-              None
-          | None -> 
-              Some (pp_pp_name mvr ^ " " ^ svi); }
+        pp_pretty_rhs     = pp_pretty_rhs_if_not_suppressed mvd.mvd_rep (pp_pp_name mvr ^ " " ^ svi); }
 (*        pp_raw_rhs        = Some (" string \"\\\"\" ^^ string " ^ svi ^ " ^^ string \"\\\"\"");
         pp_pretty_rhs     = "string "^ svi ; }
  *)
       
   | Lang_list elb -> 
       if not allow_lists then raise (Failure "unexpected list form");
-      let element_data = List.map (element_data_of_element xd ts false true indent_nonterms ) elb.elb_es in 
+      let element_data = element_data_of_elements xd ts false true indent_nonterms elb.elb_es in 
       
-      let svi = menhir_semantic_value_id_of_list elb.elb_es in      
+      let svi = required_semantic_value_id "Lang_list" semantic_value_id in
+      let element_svis = Auxl.option_map (function x -> x.semantic_value_id) element_data in      
 
       let body = 
         let list_grammar_constructor body = 
@@ -611,39 +644,41 @@ let rec element_data_of_element xd ts (allow_lists:bool) (indent_nonterms:bool) 
           | _ -> 
               Printf.sprintf "tuple%d(%s)" (List.length element_data) (String.concat "," (List.map (function x->x.grammar_body) element_data))) in
         list_grammar_constructor body0 in
-
+      
+      let pat = "(" ^ String.concat "," element_svis ^")" in
       let action = 
         (* if need be (but not otherwise) project out unit elements from terminals within list *)
         if List.exists (function x-> x.semantic_value_id = None)  element_data  then 
-          let pat = String.concat "," (List.map (function x -> match x.semantic_value_id with Some svi->svi | None->"()") element_data) in
-          let rhs = String.concat "," (Auxl.option_map (function x -> x.semantic_value_id) element_data) in
+          let pat =
+            String.concat ","
+              (List.map
+                 (function x -> match x.semantic_value_id with Some svi->svi | None->"()")
+                 element_data) in
+          let rhs = String.concat "," element_svis in
           "List.map (function ("^pat^") -> ("^rhs^")) "^svi
         else 
           svi  in
-      
-      let pat = "(" ^ String.concat "," (Auxl.option_map (function x -> x.semantic_value_id) element_data) ^")" in
 
+      let list_map rhs = "List.map (function "^pat^" -> "^rhs^") " ^ svi in
+      
       let pp_raw_rhs = 
         let rhs_data = Auxl.option_map (function x-> x.pp_raw_rhs) element_data in
         let rhs =  "string \"(\" ^^ " ^ String.concat  " ^^ string \",\" ^^ " rhs_data ^ " ^^ string \")\"" in
-        let f = "(function "^pat^" -> "^rhs^")" in
-        let pper = "string \"[\" ^^ separate  (string \";\") (List.map " ^ f ^ " " ^ svi ^")" ^" ^^ string \"]\"" in
+        let pper = "string \"[\" ^^ separate  (string \";\") (" ^ list_map rhs ^ ")" ^" ^^ string \"]\"" in
         pper in
 
       let pp_json_rhs = 
         let rhs_data = Auxl.option_map (function x-> x.pp_json_rhs) element_data in
         let rhs =  "string \"\" ^^ " ^ String.concat  " ^^ string \",\" ^^ " rhs_data ^ " ^^ string \"\"" in
-        let f = "(function "^pat^" -> "^rhs^")" in
-        let pper = "string \"\\\"list\\\" : [\" ^^ separate  (string \",\") (List.map " ^ f ^ " " ^ svi ^")" ^" ^^ string \"]\"" in
+        let pper = "string \"\\\"list\\\" : [\" ^^ separate  (string \",\") (" ^ list_map rhs ^ ")" ^" ^^ string \"]\"" in
         pper in
 
       
       let pp_pretty_rhs = 
         let rhs_data = Auxl.option_map (function x-> x.pp_pretty_rhs) element_data in
         let rhs =  String.concat  " ^^ string \" \" ^^ " rhs_data in
-        let f = "(function "^pat^" -> "^rhs^")" in
         let sep = match elb.elb_tmo with Some t -> "(string \""^String.escaped t^"\")" | None -> "(break 1)" in
-        let pper = "group(separate " ^  sep ^ " (List.map " ^ f ^ " " ^ svi ^ "))" in
+        let pper = "group(separate " ^  sep ^ " (" ^ list_map rhs ^ "))" in
         pper in
 
       { semantic_value_id = Some svi;
@@ -654,35 +689,11 @@ let rec element_data_of_element xd ts (allow_lists:bool) (indent_nonterms:bool) 
         pp_pretty_rhs     = Some pp_pretty_rhs ; }
         
   | _ -> raise (Failure "unexpected Lang_ form")
-        
-
-(* ensure unique names for production elements by adding numeric suffixes when needed *)
-let ensure_unique_element_names element_data =
-  (* Extract the names, apply uniqueness, then update the elements *)
-  let names = Auxl.option_map (fun elem -> elem.semantic_value_id) element_data in
-  let unique_names = Auxl.ensure_unique_names names in
-  
-  (* Now update the elements with the unique names *)
-  let name_pairs = List.combine names unique_names in
-  let name_index = ref 0 in
-  
-  List.map (fun elem ->
-    match elem.semantic_value_id with
-    | None -> elem
-    | Some id ->
-        let unique_id = List.nth unique_names !name_index in
-        incr name_index;
-        if unique_id = id then elem
-        else { elem with 
-               semantic_value_id = Some unique_id;
-               semantic_action = Some unique_id })
-    element_data
 
 let element_data_of_prod xd ts p =
   (* try indenting nonterms iff this production has a top-level terminal *)
   let indent_nonterms = List.exists (function | Lang_terminal _ -> true | _ -> false) p.prod_es in 
-  let element_data = List.map (element_data_of_element xd ts true indent_nonterms false) p.prod_es in
-  ensure_unique_element_names element_data
+  element_data_of_elements xd ts true indent_nonterms false p.prod_es
 
 
 let pp_menhir_prod_grammar element_data = 
@@ -789,25 +800,31 @@ let pp_menhir_prod yo generate_aux_info_here xd ts r p =
     let element_data = element_data_of_prod xd ts p in 
     let element_data' = element_data @ if generate_aux_info_for_prod generate_aux_info_here r p then [aux_constructor_element] else [] in
     let ppd_action = 
-      let es' = Grammar_pp.apply_hom_order (Menhir yo) xd p in
       if p.prod_sugar || (has_hom "quotient-remove" p.prod_homs && has_hom "ocaml" p.prod_homs) || r.rule_phantom || has_hom "ocaml" r.rule_homs then 
         (* ocaml hom case *)
         (* to do the proper escaping of nonterms within the hom, we need to pp here, not reuse the standard machinery *)
 "(*Case 1*) " ^ 
         let hs = (match Auxl.hom_spec_for_hom_name "ocaml" p.prod_homs with Some hs -> hs | None -> raise (Failure ("no ocaml hom for "^p.prod_name))) in
-        let es'' =  (* remove terminals from es to get Hom_index indexing right *)
-      	(List.filter
-           (function 
-             | (Lang_nonterm (_,_)|Lang_metavar (_,_)|Lang_list _) -> true
-             | Lang_terminal _ -> false
-             | (Lang_option _|Lang_sugaroption _) -> 
-               raise (Invalid_argument "com for prods with option or sugaroptions not implemented"))
-           es') in
+        let element_data_hom_order =
+          let filtered_element_data =
+            List.filter
+              (function
+                | { semantic_value_id = Some _; _ } -> true
+                | { semantic_value_id = None; _ } -> false)
+              element_data in
+          try
+            let oh = List.assoc "order" p.prod_homs in
+            let ohi = Auxl.option_map (fun hse -> match hse with Hom_index i -> Some i | _ -> None) oh in
+            List.map (fun i -> List.nth filtered_element_data i) ohi
+          with Not_found ->
+            filtered_element_data in
         let pp_menhir_hse hse = 
           match hse with
           | Hom_string s ->  s
           (* TODO, arbitrary failure? *)
-          | Hom_index i -> let e = List.nth es'' (*or es? *) i  in let d=element_data_of_element xd ts true false false e in (match d.semantic_action with Some s -> s | None -> raise (Failure ("pp_menhir_hse Hom_index " ^ string_of_int i ^ " at " ^ Location.pp_loc p.prod_loc)))
+          | Hom_index i ->
+              let d = List.nth element_data_hom_order i in
+              (match d.semantic_action with Some s -> s | None -> raise (Failure ("pp_menhir_hse Hom_index " ^ string_of_int i ^ " at " ^ Location.pp_loc p.prod_loc)))
           | Hom_terminal s -> s
           | Hom_ln_free_index (mvs,s) -> raise (Failure "Hom_ln_free_index not implemented")  in
         String.concat "" (List.map pp_menhir_hse hs)
@@ -1318,4 +1335,3 @@ let pp_pp_syntaxdefn m sources xd_quotiented xd_unquotiented xd_quotiented_unaux
                       ^ pp_pp_json_metavar_defns_and_rules yo generate_aux_info xd ts xd.xd_mds xd.xd_rs
                    );
   close_out fd;
-

--- a/src/lex_menhir_pp.mli
+++ b/src/lex_menhir_pp.mli
@@ -34,8 +34,7 @@ val pp_lex_systemdefn :
   Types.pp_mode -> Types.systemdefn -> (string * (string list)) list -> unit
 
 val pp_menhir_syntaxdefn :
-  Types.pp_mode -> string -> Types.syntaxdefn -> Types.syntaxdefn -> Types.made_parser -> bool -> (string * (string list)) list -> unit
+  Types.pp_mode -> string -> Types.syntaxdefn -> Types.systemdefn -> Types.made_parser -> bool -> (string * (string list)) list -> unit
 
 val pp_pp_syntaxdefn :
   Types.pp_mode -> string -> Types.syntaxdefn -> Types.syntaxdefn -> Types.syntaxdefn -> bool -> bool -> (string * (string list)) list -> string -> unit
-

--- a/src/ln_transform.ml
+++ b/src/ln_transform.ml
@@ -355,9 +355,10 @@ let ln_add_lc_judgment m xd =
 	prod_es = [Lang_terminal ("lc_"^ntr); Lang_nonterm (ntr, (ntr,[])) ];
 	prod_homs = [];
 	prod_disambiguate = None;
-        prod_bs = [];
+	prod_bs = [];
 	prod_loc = dummy_loc } ];
       rule_homs = [];
+      rule_embeds = [];
       rule_meta = true;    
       rule_semi_meta = false;
       rule_phantom = false;
@@ -531,6 +532,7 @@ let ln_transform_syntaxdefn (m:pp_mode) (xd:syntaxdefn) : syntaxdefn =
 	  prod_loc = dummy_loc }
       ];
       rule_homs = [];
+      rule_embeds = [];
       rule_meta = true;
       rule_semi_meta = true;
       rule_phantom = true;
@@ -565,7 +567,11 @@ let ln_transform_syntaxdefn (m:pp_mode) (xd:syntaxdefn) : syntaxdefn =
   ln_debug "*****************************";
   ln_debug "*** transformed syntaxdef ***";
   ln_debug "*****************************";
-  ln_debug (Grammar_pp.pp_syntaxdefn error_opts xd); 
+  let lookup = Term_parser.make_parser xd in
+  ln_debug
+    (Grammar_pp.pp_syntaxdefn
+       ~string_of_embeds:(Embed_pp.string_of_embeds error_opts xd lookup)
+       error_opts xd lookup); 
   xd
 
 
@@ -1837,4 +1843,3 @@ Tactic Notation \"apply_fresh\" \"*\" constr(T) \"as\" ident(x) :=
    Arthur defines only bgvar for patterns.  Can we assume that if a
    variable has a auxfn defined on it will never be in non-binding
    position? *)
-

--- a/src/main.ml
+++ b/src/main.ml
@@ -94,6 +94,7 @@ let rocq_lngen = ref false
 let rocq_names_in_rules = ref true
 let rocq_use_filter_fn = ref false
 let merge_fragments = ref false
+let preserve_structure = ref None  (* None = smart default based on merge_fragments *)
 let picky_multiple_parses = ref false
 let caml_include_terminals = ref false
 
@@ -148,9 +149,12 @@ let options = Arg.align [
     Arg.Tuple[Arg.String (fun s -> caml_filter_filename_srcs := s :: !caml_filter_filename_srcs);
               Arg.String (fun s -> caml_filter_filename_dsts := s :: !caml_filter_filename_dsts)],
     "<src><dst>  Files to OCaml filter" ); 
-  ( "-merge", 
-    Arg.Bool (fun b -> merge_fragments := b), 
-    "<"^string_of_bool !merge_fragments ^">         merge grammar and definition rules" ); 
+  ( "-merge",
+    Arg.Bool (fun b -> merge_fragments := b),
+    "<"^string_of_bool !merge_fragments ^">         merge grammar and definition rules" );
+  ( "-preserve-structure",
+    Arg.Bool (fun b -> preserve_structure := Some b),
+    "<auto>             preserve source file structure in output (default: false with -merge, true otherwise)" );
 
   ( "-parse", 
     Arg.String (fun s -> test_parse_list := !test_parse_list @ [s]),
@@ -775,31 +779,38 @@ let output_stage (sd,lookup,sd_unquotiented,sd_quotiented_unaux) =
     List.map (fun (t,fs) -> t, compute_output [] fs) sources_per_target 
   in
 
+  (* Compute effective preserve_structure value with smart default *)
+  let effective_preserve_structure =
+    match !preserve_structure with
+    | Some b -> b
+    | None -> not !merge_fragments  (* Smart default for backward compatibility *)
+  in
+
   (** target outputs *)
-  List.iter 
-    (fun (t,fi) -> 
-      
+  List.iter
+    (fun (t,fi) ->
+
       match t with
-      | "tex" -> 
+      | "tex" ->
           System_pp.pp_systemdefn_core_tex m_tex sd lookup fi
-      | "rocq" | "coq" -> 
-          let sd = 
+      | "rocq" | "coq" ->
+          let sd =
             ( match !rocq_avoid with
             | 0 -> sd
             | 1 -> Auxl.avoid_primaries_systemdefn false sd
             | 2 -> Auxl.avoid_primaries_systemdefn true sd
             | _ -> Auxl.error None "rocq type-name avoidance must be in {0,1,2}" ) in
-          System_pp.pp_systemdefn_core_io m_coq sd sd.syntax lookup fi !merge_fragments
+          System_pp.pp_systemdefn_core_io m_coq sd sd.syntax lookup fi !merge_fragments effective_preserve_structure
       | "isa" ->
-          System_pp.pp_systemdefn_core_io m_isa sd sd.syntax lookup fi !merge_fragments
+          System_pp.pp_systemdefn_core_io m_isa sd sd.syntax lookup fi !merge_fragments effective_preserve_structure
       | "hol" ->
-          System_pp.pp_systemdefn_core_io m_hol sd sd.syntax lookup fi !merge_fragments
+          System_pp.pp_systemdefn_core_io m_hol sd sd.syntax lookup fi !merge_fragments effective_preserve_structure
       | "lem" ->
-          System_pp.pp_systemdefn_core_io m_lem sd sd.syntax lookup fi !merge_fragments
-      | "twf" -> 
-          System_pp.pp_systemdefn_core_io m_twf sd sd.syntax lookup fi !merge_fragments
-      | "ocaml" -> 
-          System_pp.pp_systemdefn_core_io m_caml (Auxl.caml_rename sd) sd.syntax lookup fi !merge_fragments
+          System_pp.pp_systemdefn_core_io m_lem sd sd.syntax lookup fi !merge_fragments effective_preserve_structure
+      | "twf" ->
+          System_pp.pp_systemdefn_core_io m_twf sd sd.syntax lookup fi !merge_fragments effective_preserve_structure
+      | "ocaml" ->
+          System_pp.pp_systemdefn_core_io m_caml (Auxl.caml_rename sd) sd.syntax lookup fi !merge_fragments effective_preserve_structure
       | "lex" -> 
           Lex_menhir_pp.pp_lex_systemdefn m_lex (Auxl.caml_rename sd) fi
       | "menhir" -> 

--- a/src/main.ml
+++ b/src/main.ml
@@ -650,9 +650,14 @@ let process source_filenames =
   in
 
 
+  let lookup = Term_parser.make_parser xd in 
+
   if !show_sort then (
     print_endline "********** AFTER CHECK, DISAMBIGUATE AND SORT  *********************\n"; 
-    print_endline (Grammar_pp.pp_syntaxdefn m_ascii xd));
+    print_endline
+      (Grammar_pp.pp_syntaxdefn
+         ~string_of_embeds:(Embed_pp.string_of_embeds m_ascii xd lookup)
+         m_ascii xd lookup));
 
   (* FZ sorting is now performed while checking and disambiguate *)
   (* let xd =  *)
@@ -667,8 +672,6 @@ let process source_filenames =
 
   (* make parser for symbolic terms *)
 
-  let lookup = Term_parser.make_parser xd in 
-  
   begin try
     Grammar_typecheck.check_with_parser lookup xd
   with
@@ -786,17 +789,17 @@ let output_stage (sd,lookup,sd_unquotiented,sd_quotiented_unaux) =
             | 1 -> Auxl.avoid_primaries_systemdefn false sd
             | 2 -> Auxl.avoid_primaries_systemdefn true sd
             | _ -> Auxl.error None "rocq type-name avoidance must be in {0,1,2}" ) in
-          System_pp.pp_systemdefn_core_io m_coq sd lookup fi !merge_fragments
+          System_pp.pp_systemdefn_core_io m_coq sd sd.syntax lookup fi !merge_fragments
       | "isa" ->
-          System_pp.pp_systemdefn_core_io m_isa sd lookup fi !merge_fragments
+          System_pp.pp_systemdefn_core_io m_isa sd sd.syntax lookup fi !merge_fragments
       | "hol" ->
-          System_pp.pp_systemdefn_core_io m_hol sd lookup fi !merge_fragments
+          System_pp.pp_systemdefn_core_io m_hol sd sd.syntax lookup fi !merge_fragments
       | "lem" ->
-          System_pp.pp_systemdefn_core_io m_lem sd lookup fi !merge_fragments
+          System_pp.pp_systemdefn_core_io m_lem sd sd.syntax lookup fi !merge_fragments
       | "twf" -> 
-          System_pp.pp_systemdefn_core_io m_twf sd lookup fi !merge_fragments
+          System_pp.pp_systemdefn_core_io m_twf sd sd.syntax lookup fi !merge_fragments
       | "ocaml" -> 
-          System_pp.pp_systemdefn_core_io m_caml (Auxl.caml_rename sd) lookup fi !merge_fragments
+          System_pp.pp_systemdefn_core_io m_caml (Auxl.caml_rename sd) sd.syntax lookup fi !merge_fragments
       | "lex" -> 
           Lex_menhir_pp.pp_lex_systemdefn m_lex (Auxl.caml_rename sd) fi
       | "menhir" -> 
@@ -805,7 +808,7 @@ let output_stage (sd,lookup,sd_unquotiented,sd_quotiented_unaux) =
           let xd_quotiented = sd_quotiented.syntax in
           let xd_unquotiented = sd_unquotiented.syntax in
           let xd_quotiented_unaux = sd_quotiented_unaux.syntax in
-          (Lex_menhir_pp.pp_menhir_syntaxdefn m_menhir sd.sources xd_quotiented xd_unquotiented lookup !generate_aux_rules fi;
+          (Lex_menhir_pp.pp_menhir_syntaxdefn m_menhir sd.sources xd_quotiented sd_unquotiented lookup !generate_aux_rules fi;
            Lex_menhir_pp.pp_pp_syntaxdefn m_menhir sd.sources xd_quotiented xd_unquotiented xd_quotiented_unaux !generate_aux_rules true fi "")
 
      | _ -> Auxl.int_error("unknown target "^t))

--- a/src/main.ml
+++ b/src/main.ml
@@ -292,20 +292,19 @@ let options = Arg.align [
   ( "-no_rbcatn", 
     Arg.Bool (fun b -> Substs_pp.no_rbcatn := b),
     "<"^string_of_bool !Substs_pp.no_rbcatn^">      (debug) remove relevant bind clauses" ); 
-  ( "-lem_debug", 
+  ( "-lem_debug",
     Arg.Bool (fun b -> Types.lem_debug := b),
-    "        (debug) print lem debug locations" ); 
+    "        (debug) print lem debug locations" );
+  ( "-quiet",
+    Arg.Set Global_option.quiet,
+    "          Suppress normal output (keep errors/warnings)" );
 ] 
 
-let usage_msg = 
+let usage_msg =
     ("\n"
-     ^ "usage: ott <options> <filename1> .. <filenamen> \n" 
+     ^ "usage: ott <options> <filename1> .. <filenamen> \n"
      ^ "  (use \"OCAMLRUNPARAM=p  ott ...\" to show the ocamlyacc trace)\n"
      ^ "  (ott <options> <filename1> .. <filenamen>    is equivalent to\n   ott -i <filename1> .. -i <filenamen> <options>)\n")
-
-
-
-let _ = print_string ("Ott version "^Version.n^"   distribution of "^Version.d^"\n")
 
 (* Normalize flag names: replace "coq" with "rocq" for backward compatibility *)
 let normalize_flag flag =
@@ -327,7 +326,12 @@ let _ =
   with
   | Arg.Help msg -> print_string msg; exit 0
   | Arg.Bad msg -> print_string msg; exit 2);
-  file_arguments :=  !file_arguments @ !extra_arguments 
+  file_arguments :=  !file_arguments @ !extra_arguments
+
+(* Print version unless in quiet mode *)
+let _ =
+  if not !Global_option.quiet then
+    print_string ("Ott version "^Version.n^"   distribution of "^Version.d^"\n")
 
 let _ = tex_filter_filenames := List.combine (!tex_filter_filename_srcs) (!tex_filter_filename_dsts)
 let _ = hol_filter_filenames := List.combine (!hol_filter_filename_srcs) (!hol_filter_filename_dsts)
@@ -741,7 +745,8 @@ let output_stage (sd,lookup,sd_unquotiented,sd_quotiented_unaux) =
             (Types.systemdefn * (string -> bool -> string -> Types.symterm list) * Types.systemdefn * Types.systemdefn))
         [Marshal.Closures];
       close_out fd;
-      print_string ("system definition in file: " ^ s ^ "\n") );
+      if not !Global_option.quiet then
+        print_string ("system definition in file: " ^ s ^ "\n") );
   
   (** dot output of dependencies *)
   ( match !dot_filename_opt with
@@ -751,7 +756,8 @@ let output_stage (sd,lookup,sd_unquotiented,sd_quotiented_unaux) =
       output_string fd
         (Grammar_pp.pp_dot_dep_graph pp_ascii_opts_default sd.syntax);
       close_out fd;
-      print_string ("dot version in file: " ^ s ^ "\n") );
+      if not !Global_option.quiet then
+        print_string ("dot version in file: " ^ s ^ "\n") );
 
   (* for each target, compute the o/is informations *)
   let output_details =
@@ -783,7 +789,7 @@ let output_stage (sd,lookup,sd_unquotiented,sd_quotiented_unaux) =
   let effective_preserve_structure =
     match !preserve_structure with
     | Some b -> b
-    | None -> not !merge_fragments  (* Smart default for backward compatibility *)
+    | None -> not !merge_fragments
   in
 
   (** target outputs *)
@@ -899,7 +905,8 @@ let output_stage (sd,lookup,sd_unquotiented,sd_quotiented_unaux) =
 
   if !process_defns then begin
     let bad, msg = Defns.pp_counts sd in
-    print_string msg;
+    if not !Global_option.quiet then
+      print_string msg;
     if bad && !signal_parse_errors then exit 1
   end;
   ()

--- a/src/new_term_parser.ml
+++ b/src/new_term_parser.ml
@@ -900,10 +900,17 @@ let build_grammar (xd : syntaxdefn)
 
     end; 
 
+    let find_prodname_index2 pn loc =
+      try Hashtbl.find prodname_to_index2 pn with
+      | Not_found ->
+          Auxl.error (Some loc)
+            ("internal error: missing parser production for parsing annotation prodname \""
+             ^ pn ^ "\"")
+    in
     List.iter
       (fun (pn1, annot, pn2, loc) ->
-         let (i1, i1') = Hashtbl.find prodname_to_index2 pn1 in
-         let (i2, i2') = Hashtbl.find prodname_to_index2 pn2 in
+         let (i1, i1') = find_prodname_index2 pn1 loc in
+         let (i2, i2') = find_prodname_index2 pn2 loc in
          let entry = 
            match annot with
                Types.LTEQ -> [Greater (i2, i1); Greater (i2', i1)]

--- a/src/quotient_rules.ml
+++ b/src/quotient_rules.ml
@@ -49,8 +49,8 @@ In the quotiented grammar, for each rule with a {{ quotient-with ntr }} hom:
 
 Any productions with a {{ quotient-remove }} hom is discarded.
 
-Implementation: This is done on raw_syntaxdefn's, in the first part of
-Grammar_typecheck.check_and_disambiguate.  It should be before aux
+Implementation: This is done on the raw item stream, in the first part
+of Grammar_typecheck.check_and_disambiguate.  It should be before aux
 rule synthesis, which makes it easier to do on a per-item basis, ie
 *within* each "grammar" block (perhaps an unfortunate limitation).
 
@@ -208,7 +208,7 @@ let quotient_rules m_tex (rs: raw_rule list) :  raw_rule list =
 *)
   
   (* construct one quotiented rule *)
-  let quotient_rule (r:raw_rule) (rs: (raw_rule * nontermroot) list) : raw_rule = 
+  let quotient_rule (rs_all:raw_rule list) (r:raw_rule) (rs: (raw_rule * nontermroot) list) : raw_rule = 
     
     (* check the production-name prefixes are identical *)
     let () = List.iter (function (r',_) -> if r'.raw_rule_pn_wrapper <> r.raw_rule_pn_wrapper then ty_error2 r'.raw_rule_loc ("quotiented rule production-name prefix "^r'.raw_rule_pn_wrapper^" does not match that of the target rule ("^r.raw_rule_pn_wrapper^")") "") rs in
@@ -234,6 +234,14 @@ let quotient_rules m_tex (rs: raw_rule list) :  raw_rule list =
       let homs' = tex_hom :: List.filter (function (hn,_,_)-> hn<>"tex") homs in
       (ntr,homs') in
 
+    let participant_names = r.raw_rule_ntr_name :: List.map (fun (r',_) -> r'.raw_rule_ntr_name) rs in
+    let rule_embeds =
+      List.concat
+        (List.map
+           (fun rule -> rule.raw_rule_embeds)
+           (List.filter (fun rule -> List.mem rule.raw_rule_ntr_name participant_names) rs_all))
+    in
+
     { r with 
       raw_rule_ntr_names = List.flatten (r.raw_rule_ntr_names :: List.map (function (r',ntr_target) -> List.map (add_tex_ntr_hom r'.raw_rule_loc ntr_target) r'.raw_rule_ntr_names) rs);
       raw_rule_ps = strip_quotient_remove_prods 
@@ -242,6 +250,7 @@ let quotient_rules m_tex (rs: raw_rule list) :  raw_rule list =
            (List.map 
               (function (r',_) -> (*List.map (rename_raw_prod renaming)*) r'.raw_rule_ps)
               rs)));
+      raw_rule_embeds = rule_embeds;
     }  in
 
   let rec f qd rs_all rs = 
@@ -254,10 +263,9 @@ let quotient_rules m_tex (rs: raw_rule list) :  raw_rule list =
             let rs_ntrs_to_be_quotiented_in = Auxl.option_map (function (ntr',ntrs',ntrlo') -> match ntrlo' with Some (ntr'',l) when List.mem ntr'' ntrs -> Some (ntr',ntr'') | _ -> None) quotient_data in
             (* the actual rules, with the ntr target for each *)
             let rs_to_be_quotiented_in = List.map (function (ntr,ntr_target) -> (List.find (function r' -> r'.raw_rule_ntr_name = ntr) rs_all, ntr_target)) rs_ntrs_to_be_quotiented_in in
-            (quotient_rule r rs_to_be_quotiented_in) :: f qd' rs_all rs')
+            (quotient_rule rs_all r rs_to_be_quotiented_in) :: f qd' rs_all rs')
     | ([], []) -> []
     | _ -> raise (Failure "quotient rules")
 
   in
    f quotient_data rs rs 
-

--- a/src/system_pp.ml
+++ b/src/system_pp.ml
@@ -439,12 +439,13 @@ let pp_systemdefn fd m sd embed_syntax lookup fn =
 
 (* multi-file stuff *)
 
-let pp_systemdefn_core_io m sd embed_syntax lookup oi merge_fragments =
-  (* if -merge true, ignore the new algorithm *)
-  if merge_fragments
+let pp_systemdefn_core_io m sd embed_syntax lookup oi merge_fragments preserve_structure =
+  ignore merge_fragments;
+  (* if -preserve-structure false, use old monolithic algorithm *)
+  if not preserve_structure
   then begin
-    let o = match oi with (o,is)::[] -> o 
-    | _ -> Auxl.error None "must specify only one output file .\n" in
+    let o = match oi with (o,is)::[] -> o
+    | _ -> Auxl.error None "must specify only one output file when -preserve-structure false\n" in
     let fn = Auxl.filename_check m o in
     let fd = open_out o in
     pp_systemdefn fd m sd embed_syntax lookup fn;

--- a/src/system_pp.ml
+++ b/src/system_pp.ml
@@ -112,13 +112,62 @@ let set_locally_nameless m =
   (* TODO *)
   | _ -> Auxl.error None "locally-nameless: only the Coq backend understand {{ repr-locally-nameless }}.\n"
 
+let apply_rule_embed_side_effects m xd lookup rs =
+  List.iter
+    (fun r ->
+       Embed_pp.apply_embeds_side_effects m xd lookup r.rule_embeds)
+    rs
+
+let embeds_for_input_files input_files embeds =
+  List.filter
+    (fun (l,_,_) -> List.mem (Location.extract_file l) input_files)
+    embeds
+
+let prepare_whole_file_embed_side_effects m xd lookup embed_preamble embeds =
+  Embed_pp.apply_embeds_side_effects m xd lookup embed_preamble;
+  Embed_pp.apply_embeds_side_effects m xd lookup embeds
+
+let prepare_structure_embed_side_effects m xd lookup structure =
+  List.iter
+    (function
+      | (_, Struct_rs ntrs) ->
+          let rs = List.map (fun ntr -> Auxl.rule_of_ntr xd ntr) ntrs in
+          apply_rule_embed_side_effects m xd lookup rs
+      | (_, Struct_embed embed) ->
+          Embed_pp.apply_embeds_side_effects m xd lookup [embed]
+      | _ -> ())
+    structure
+
+let pp_library fd m = 
+  let pp_lib x =
+    let l = fst !x in
+    if l <> "" then begin
+      output_string fd (Auxl.big_line_comment m "library functions");
+      output_string fd l;
+      x := ("", snd !x)
+    end in
+  match m with
+    | Isa io -> pp_lib io.isa_library
+    | Hol ho -> pp_lib ho.hol_library 
+    | Lem lo -> pp_lib lo.lem_library 
+    | Coq co -> pp_lib co.coq_library
+    | Twf wo -> pp_lib wo.twf_library
+    | Caml oo-> pp_lib oo.caml_library
+    | Ascii _ | Tex _ | Lex _ | Menhir _ -> Auxl.errorm m "pp_library"
+
 let pp_systemdefn_core_locally_nameless fd m sd lookup = 
   set_locally_nameless m;
   let xd_ln_transformed = Ln_transform.ln_transform_syntaxdefn m sd.syntax in
   let relations_ln_transformed = Ln_transform.ln_transform_fun_or_reln_defnclass_list m sd.syntax sd.relations in 
+  let lookup_ln = Term_parser.make_parser xd_ln_transformed in
+  prepare_whole_file_embed_side_effects m sd.syntax lookup sd.syntax.xd_embed_preamble sd.syntax.xd_embed;
+  apply_rule_embed_side_effects m xd_ln_transformed lookup xd_ln_transformed.xd_rs;
   Embed_pp.pp_embeds fd m sd.syntax lookup sd.syntax.xd_embed_preamble;
   output_string fd (Auxl.big_line_comment m "syntax");
-  output_string fd (Grammar_pp.pp_syntaxdefn m xd_ln_transformed);
+  output_string fd
+    (Grammar_pp.pp_syntaxdefn
+       ~string_of_embeds:(Embed_pp.string_of_embeds m sd.syntax lookup)
+       m xd_ln_transformed lookup_ln);
   output_string fd ("\n");
   pp_functions_locally_nameless fd m sd xd_ln_transformed;
   Embed_pp.pp_embeds fd m sd.syntax lookup sd.syntax.xd_embed;
@@ -174,24 +223,7 @@ let pp_functions fd m sd lookup =
   output_string fd (Dependency.compute m sd.syntax contexts);
   ()
 
-let pp_library fd m = 
-  let pp_lib x =
-    let l = fst !x in
-    if l <> "" then begin
-      output_string fd (Auxl.big_line_comment m "library functions");
-      output_string fd l;
-      x := ("", snd !x)
-    end in
-  match m with
-    | Isa io -> pp_lib io.isa_library
-    | Hol ho -> pp_lib ho.hol_library 
-    | Lem lo -> pp_lib lo.lem_library 
-    | Coq co -> pp_lib co.coq_library
-    | Twf wo -> pp_lib wo.twf_library
-    | Caml oo-> pp_lib oo.caml_library
-    | Ascii _ | Tex _ | Lex _ | Menhir _ -> Auxl.errorm m "pp_library"
-
-let pp_struct_entry fd m sd xd_expanded lookup stre : unit =
+let pp_struct_entry fd m sd xd_expanded lookup string_of_rule_embeds embed_syntax stre : unit =
   pp_library fd m;
   ( let xd = sd.syntax in
   match stre with
@@ -201,12 +233,15 @@ let pp_struct_entry fd m sd xd_expanded lookup stre : unit =
       output_string fd pp_loc;
       output_string fd (Grammar_pp.pp_metavardefn m xd mvd)
 
-  | Struct_rs ntrs -> 
+  | Struct_rs ntrs ->
       let rs = List.map (fun ntr -> Auxl.rule_of_ntr xd_expanded ntr) ntrs in
       let s = List.flatten (List.map (function r -> r.rule_loc) rs) in
       let pp_locs = if !Global_option.output_source_locations >=2 then Grammar_pp.pp_source_location m s else "" in
       output_string fd pp_locs;
-      output_string fd (Grammar_pp.pp_rule_list m xd_expanded rs);
+      output_string fd
+        (Grammar_pp.pp_rule_list
+           ~string_of_embeds:string_of_rule_embeds
+           m xd_expanded lookup rs);
       (* induction_principles_rules *)
       ( match m with
       | Coq co when not co.coq_expand_lists ->
@@ -318,37 +353,25 @@ let pp_struct_entry fd m sd xd_expanded lookup stre : unit =
   	  (pp_locs^Dependency.compute m xd contexts))
 
   | Struct_embed embed -> 
-      Embed_pp.pp_embeds fd m sd.syntax lookup [embed] (* FIXME should be a list *)
+      Embed_pp.pp_embeds fd m embed_syntax lookup [embed] (* FIXME should be a list *)
    )
 
-let pp_systemdefn_structure fd m sd xd_expanded structure_expanded lookup =
-  List.iter (fun (_,x) -> pp_struct_entry fd m sd xd_expanded lookup x) structure_expanded
+let pp_systemdefn_structure fd m sd xd_expanded structure_expanded lookup string_of_rule_embeds embed_syntax =
+  List.iter
+    (fun (_, x) -> pp_struct_entry fd m sd xd_expanded lookup string_of_rule_embeds embed_syntax x)
+    structure_expanded
 
-(* old algorithm that ignores the structure informations: core for isa/hol/coq/twf output *)
-let pp_systemdefn_core fd m sd lookup = 
+let pp_systemdefn_core fd m sd embed_syntax lookup = 
   let xd_expanded, structure_expanded = 
     Transform.expand_lists_in_syntaxdefn m sd.syntax sd.structure in (* identity if m <> Coq *)
-  
-  output_string fd (Auxl.big_line_comment m "warning: the backend selected ignores the file structure informations");
-  Embed_pp.pp_embeds fd m sd.syntax lookup sd.syntax.xd_embed_preamble;
+  let string_of_rule_embeds = Embed_pp.string_of_embeds m embed_syntax lookup in
+  prepare_whole_file_embed_side_effects m embed_syntax lookup embed_syntax.xd_embed_preamble embed_syntax.xd_embed;
+  prepare_structure_embed_side_effects m xd_expanded lookup structure_expanded;
+  Embed_pp.pp_embeds fd m embed_syntax lookup embed_syntax.xd_embed_preamble;
   pp_auxiliary_lemmas m xd_expanded;
-  output_string fd (Auxl.big_line_comment m "syntax");
-  output_string fd (Grammar_pp.pp_syntaxdefn m xd_expanded);
-  output_string fd ("\n");
-  pp_functions fd m sd lookup;
-  Embed_pp.pp_embeds fd m sd.syntax lookup sd.syntax.xd_embed;
-  output_string fd ("\n");
-  Defns.pp_fun_or_reln_defnclass_list fd m sd.syntax lookup sd.relations;
-  output_string fd ("\n\n");
-  ( match m with
-  | Coq co when not co.coq_expand_lists ->
-      let ip = Coq_induct.pp_induction m xd_expanded xd_expanded.xd_rs in
-      if ip <> "" then begin 
-         output_string fd (Auxl.big_line_comment m "induction principles");
-         output_string fd ip;
-         output_string fd ("\n")
-      end
-  | _ -> () )
+  pp_systemdefn_structure fd m sd xd_expanded structure_expanded lookup string_of_rule_embeds embed_syntax;
+  Embed_pp.pp_embeds fd m embed_syntax lookup embed_syntax.xd_embed;
+  output_string fd "\n"
 
 (* Helper function to format Require Import statements with From Coq prefix for stdlib *)
 let format_require_import th =
@@ -357,7 +380,7 @@ let format_require_import th =
   | _ -> "Require Import " ^ th ^ "."
 
 (* old algorithm, used only when pp with -merge true *)
-let pp_systemdefn fd m sd lookup fn =
+let pp_systemdefn fd m sd embed_syntax lookup fn =
 
   match m with
   | Isa io ->
@@ -368,7 +391,7 @@ let pp_systemdefn fd m sd lookup fn =
       Printf.fprintf fd "(* generated by Ott %s from: %s *)\n" Version.n sd.sources;
       Printf.fprintf fd "theory %s\nimports %s\n" fn (String.concat " " imports);
       output_string fd "begin\n\n";
-      pp_systemdefn_core fd m sd lookup;
+      pp_systemdefn_core fd m sd embed_syntax lookup;
       output_string fd "\nend\n"
   | Hol ho ->
       Printf.fprintf fd "(* generated by Ott %s from: %s *)\n" Version.n sd.sources;
@@ -381,7 +404,7 @@ let pp_systemdefn fd m sd lookup fn =
       output_string fd "local open arithmeticTheory stringTheory containerTheory pred_setTheory listTheory \n";
       output_string fd "  finite_mapTheory in end;\n\n";
       Printf.fprintf fd "val _ = new_theory \"%s\";\n" fn;
-      pp_systemdefn_core fd m sd lookup;
+      pp_systemdefn_core fd m sd embed_syntax lookup;
       output_string fd "\nval _ = export_theory ();\n"
   | Coq co ->
       (* FZ keeping for now locally_nameless repr separated from the main *)
@@ -401,22 +424,22 @@ let pp_systemdefn fd m sd lookup fn =
                      | true -> ["Arith"; "Bool"; "List"]
                      | false -> ["Arith"; "Bool"; "List"; "Ott.ott_list_core"])
       end;
-      pp_systemdefn_core fd m sd lookup
+      pp_systemdefn_core fd m sd embed_syntax lookup
   | Twf wo ->
       Printf.fprintf fd "%%%% generated by Ott %s from: %s\n\n" Version.n sd.sources;
-      pp_systemdefn_core fd m sd lookup
+      pp_systemdefn_core fd m sd embed_syntax lookup
   | Caml oo ->
       Printf.fprintf fd "(* generated by Ott %s from: %s *)\n" Version.n sd.sources;
-      pp_systemdefn_core fd m sd lookup
+      pp_systemdefn_core fd m sd embed_syntax lookup
   | Lem lo ->
       Printf.fprintf fd "(* generated by Ott %s from: %s *)\n" Version.n sd.sources;
-      pp_systemdefn_core fd m sd lookup
+      pp_systemdefn_core fd m sd embed_syntax lookup
   | Ascii _ | Lex _ | Menhir _ | Tex _ -> Auxl.errorm m "pp_systemdefn"
      
 
 (* multi-file stuff *)
 
-let pp_systemdefn_core_io m sd lookup oi merge_fragments =
+let pp_systemdefn_core_io m sd embed_syntax lookup oi merge_fragments =
   (* if -merge true, ignore the new algorithm *)
   if merge_fragments
   then begin
@@ -424,7 +447,7 @@ let pp_systemdefn_core_io m sd lookup oi merge_fragments =
     | _ -> Auxl.error None "must specify only one output file .\n" in
     let fn = Auxl.filename_check m o in
     let fd = open_out o in
-    pp_systemdefn fd m sd lookup fn;
+    pp_systemdefn fd m sd embed_syntax lookup fn;
     close_out fd;
   end
   else if Auxl.require_locally_nameless sd.syntax
@@ -510,6 +533,7 @@ let pp_systemdefn_core_io m sd lookup oi merge_fragments =
 
       let xd_expanded, structure_expanded = 
         Transform.expand_lists_in_syntaxdefn m sd.syntax sd.structure in (* identity if m <> Coq *)
+      let string_of_rule_embeds = Embed_pp.string_of_embeds m embed_syntax lookup in
 
       (* print_endline ("**** structure after expand ***\n "^( Auxl.dump_structure_fn structure_expanded)); *)
       
@@ -518,10 +542,17 @@ let pp_systemdefn_core_io m sd lookup oi merge_fragments =
       | (o,(i::[]))::[] ->
           let fn = Auxl.filename_check m o in 
           let fd = open_out o in
-          pp_systemdefn_structure fd m sd xd_expanded ([std_preamble_embed fn]) lookup;
+          let structure_for_file =
+            [std_preamble_embed fn] @ structure_expanded @ std_postamble_embed fn
+          in
+          prepare_whole_file_embed_side_effects m embed_syntax lookup embed_syntax.xd_embed_preamble embed_syntax.xd_embed;
+          prepare_structure_embed_side_effects m xd_expanded lookup structure_for_file;
+          pp_systemdefn_structure fd m sd xd_expanded ([std_preamble_embed fn]) lookup string_of_rule_embeds embed_syntax;
+          Embed_pp.pp_embeds fd m embed_syntax lookup embed_syntax.xd_embed_preamble;
           pp_auxiliary_lemmas m xd_expanded;
-          pp_systemdefn_structure fd m sd xd_expanded structure_expanded lookup;
-          pp_systemdefn_structure fd m sd xd_expanded (std_postamble_embed fn) lookup;
+          pp_systemdefn_structure fd m sd xd_expanded structure_expanded lookup string_of_rule_embeds embed_syntax;
+          Embed_pp.pp_embeds fd m embed_syntax lookup embed_syntax.xd_embed;
+          pp_systemdefn_structure fd m sd xd_expanded (std_postamble_embed fn) lookup string_of_rule_embeds embed_syntax;
           output_string fd "\n\n";
           close_out fd
       | _ ->
@@ -530,11 +561,24 @@ let pp_systemdefn_core_io m sd lookup oi merge_fragments =
               let fn = Auxl.filename_check m o in
               let struct_subset = 
                 List.filter (fun (fn,s) -> List.mem fn is) structure_expanded in
+              let embed_preamble_subset =
+                embeds_for_input_files is embed_syntax.xd_embed_preamble
+              in
+              let embed_subset =
+                embeds_for_input_files is embed_syntax.xd_embed
+              in
               let fd = open_out o in
-              pp_systemdefn_structure fd m sd xd_expanded ([std_preamble_embed fn]) lookup;
+              let structure_for_file =
+                [std_preamble_embed fn] @ struct_subset @ std_postamble_embed fn
+              in
+              prepare_whole_file_embed_side_effects m embed_syntax lookup embed_preamble_subset embed_subset;
+              prepare_structure_embed_side_effects m xd_expanded lookup structure_for_file;
+              pp_systemdefn_structure fd m sd xd_expanded ([std_preamble_embed fn]) lookup string_of_rule_embeds embed_syntax;
+              Embed_pp.pp_embeds fd m embed_syntax lookup embed_preamble_subset;
               pp_auxiliary_lemmas m xd_expanded;
-              pp_systemdefn_structure fd m sd xd_expanded struct_subset lookup;
-              pp_systemdefn_structure fd m sd xd_expanded (std_postamble_embed fn) lookup;
+              pp_systemdefn_structure fd m sd xd_expanded struct_subset lookup string_of_rule_embeds embed_syntax;
+              Embed_pp.pp_embeds fd m embed_syntax lookup embed_subset;
+              pp_systemdefn_structure fd m sd xd_expanded (std_postamble_embed fn) lookup string_of_rule_embeds embed_syntax;
               output_string fd "\n\n";
               close_out fd)
             oi
@@ -542,6 +586,48 @@ let pp_systemdefn_core_io m sd lookup oi merge_fragments =
 
 let is_wrap_pre (l,hn,es) = if hn = "tex-wrap-pre" then Some (l,"tex",es) else None
 let is_wrap_post (l,hn,es) = if hn = "tex-wrap-post" then Some (l,"tex",es) else None
+
+let pp_tex_syntaxdefn_from_structure m sd lookup structure =
+  let () =
+    match m with
+    | Tex _ -> ()
+    | _ -> Auxl.error None "internal: pp_tex_syntaxdefn_from_structure on non-tex pp_mode\n"
+  in
+  let tex_item s = if s = "" then None else Some s in
+  let string_of_embeds = Embed_pp.string_of_embeds m sd.syntax lookup in
+  let add_structure_entry (metavar_lines, rule_defs, grammar_items) (_, stre) =
+    match stre with
+    | Struct_md mvr ->
+        let mvd = Auxl.mvd_of_mvr sd.syntax mvr in
+        (metavar_lines @ [Grammar_pp.pp_metavardefn m sd.syntax mvd], rule_defs, grammar_items)
+    | Struct_rs ntrs ->
+        let rs = List.map (fun ntr -> Auxl.rule_of_ntr sd.syntax ntr) ntrs in
+        ( metavar_lines,
+          rule_defs @ Auxl.option_map (Grammar_pp.pp_rule m sd.syntax) rs,
+          grammar_items @ Grammar_pp.tex_rule_grammar_items ~string_of_embeds m rs )
+    | Struct_embed embed ->
+        begin
+          match tex_item (string_of_embeds [embed]) with
+          | None -> (metavar_lines, rule_defs, grammar_items)
+          | Some item -> (metavar_lines, rule_defs, grammar_items @ [item])
+        end
+    | Struct_srs _ | Struct_crs _ | Struct_axs _ | Struct_sbs _ | Struct_fvs _
+    | Struct_fun_or_defnclass _ ->
+        (metavar_lines, rule_defs, grammar_items)
+  in
+  let metavar_lines, rule_defs, grammar_items =
+    List.fold_left add_structure_entry ([], [], []) structure
+  in
+  "\\newcommand{"^Grammar_pp.pp_tex_METAVARS_NAME m^"}{\n"
+  ^ Grammar_pp.pp_tex_BEGIN_METAVARS m
+  ^ String.concat "\n" metavar_lines
+  ^ "\n"^Grammar_pp.pp_tex_END_METAVARS ^"}\n\n"
+  ^ String.concat "\n" rule_defs
+  ^ "\\newcommand{"^Grammar_pp.pp_tex_RULES_NAME m^"}{"
+  ^ Grammar_pp.pp_tex_BEGIN_RULES m
+  ^ String.concat (Grammar_pp.pp_tex_INTERRULE_NAME m ^"\n") grammar_items
+  ^ (match grammar_items with [] -> "" | _ -> Grammar_pp.pp_tex_AFTERLASTRULE_NAME m)
+  ^ "\n"^Grammar_pp.pp_tex_END_RULES ^ "}\n\n"
 
 let pp_systemdefn_core_tex m sd lookup oi =
   let xo = match m with | Tex xo -> xo | _ -> Auxl.error None "internal: pp_systemdefn_core_tex on non-tex pp_mode\n" in
@@ -594,7 +680,7 @@ let pp_systemdefn_core_tex m sd lookup oi =
       Printf.fprintf fd ("\\newcommand{%s}{\\\\[5.0mm]}\n") (Grammar_pp.pp_tex_INTERRULE_NAME m );
       Printf.fprintf fd ("\\newcommand{%s}{\\\\}\n") (Grammar_pp.pp_tex_AFTERLASTRULE_NAME m );
       Embed_pp.pp_embeds fd m sd.syntax lookup sd.syntax.xd_embed_preamble;
-      output_string fd (Grammar_pp.pp_syntaxdefn m sd.syntax);
+      output_string fd (pp_tex_syntaxdefn_from_structure m sd lookup sd.structure);
       Defns.pp_fun_or_reln_defnclass_list fd m sd.syntax lookup sd.relations;
       Printf.fprintf fd ("\\newcommand{%s}{%s\\\\[0pt]\n%s\\\\[5.0mm]\n")
         (Grammar_pp.pp_tex_ALL_NAME m)
@@ -614,4 +700,3 @@ let pp_systemdefn_core_tex m sd lookup oi =
       end;
       close_out fd;
   | _ -> Auxl.error None "must specify only one output file in the TeX backend.\n"
-

--- a/src/system_pp.mli
+++ b/src/system_pp.mli
@@ -34,7 +34,6 @@
 (* val pp_systemdefn : *)
 (*  Types.pp_mode -> Types.systemdefn -> Types.made_parser -> string *)
 val pp_systemdefn_core_io :
-  Types.pp_mode -> Types.systemdefn -> Types.made_parser -> (string * (string list)) list -> bool -> unit
+  Types.pp_mode -> Types.systemdefn -> Types.syntaxdefn -> Types.made_parser -> (string * (string list)) list -> bool -> unit
 val pp_systemdefn_core_tex :
   Types.pp_mode -> Types.systemdefn -> Types.made_parser -> (string * (string list)) list -> unit
-

--- a/src/system_pp.mli
+++ b/src/system_pp.mli
@@ -34,6 +34,6 @@
 (* val pp_systemdefn : *)
 (*  Types.pp_mode -> Types.systemdefn -> Types.made_parser -> string *)
 val pp_systemdefn_core_io :
-  Types.pp_mode -> Types.systemdefn -> Types.syntaxdefn -> Types.made_parser -> (string * (string list)) list -> bool -> unit
+  Types.pp_mode -> Types.systemdefn -> Types.syntaxdefn -> Types.made_parser -> (string * (string list)) list -> bool -> bool -> unit
 val pp_systemdefn_core_tex :
   Types.pp_mode -> Types.systemdefn -> Types.made_parser -> (string * (string list)) list -> unit

--- a/src/transform.ml
+++ b/src/transform.ml
@@ -240,6 +240,7 @@ let expand_element (m:pp_mode) (xd:syntaxdefn) (bs:bindspec list) (e:element) :
 	  rule_pn_wrapper = "";
 	  rule_ps = [ nil_prod; cons_prod ];
 	  rule_homs = [("rocq-universe", [Hom_string id_universe])];
+	  rule_embeds = [];
 	  rule_meta = false;
 	  rule_semi_meta = false;
           rule_phantom = false;
@@ -414,4 +415,3 @@ let expand_lists_in_syntaxdefn (m:pp_mode) (xd:syntaxdefn) (structure: structure
       expanded_structure
 
   | _ -> xd, structure
-

--- a/src/types.ml
+++ b/src/types.ml
@@ -231,6 +231,7 @@ and rule =  (* r *)
       rule_pn_wrapper : string;
       rule_ps : prod list;
       rule_homs : homomorphism list;
+      rule_embeds : embed list;
       rule_meta : bool; 
         (* semi_meta OR rule occurs as srs_lower OR phantom *)
       rule_semi_meta : bool; 
@@ -635,6 +636,7 @@ and raw_rule =
       raw_rule_pn_wrapper : string;
       raw_rule_ps : raw_prod list;
       raw_rule_homs : raw_homomorphism list;
+      raw_rule_embeds : raw_embed list;
       raw_rule_categories : string list;
       raw_rule_loc : loc }
 
@@ -705,19 +707,6 @@ and raw_item = (* ri *)
   | Raw_item_hs of raw_hom_section 
   | Raw_item_coq_section of raw_coq_section
   | Raw_item_coq_variable of raw_coq_variable
-   
-and raw_syntaxdefn = 
-    { raw_sd_mds : raw_metavardefn list; 
-      raw_sd_rs : raw_rule list;
-      raw_sd_dcs : raw_fun_or_reln_defnclass list;
-      raw_sd_srs : raw_subrule list;
-      raw_sd_crs : raw_contextrule list;
-      raw_sd_sbs : raw_subst list;
-      raw_sd_fvs : raw_freevar list;
-      raw_sd_embed : raw_embed list;
-      raw_sd_pas : raw_parsing_annotations list;
-      raw_sd_hss : raw_hom_section list;
-      raw_sd_loc : loc }         (* FZ shall we keep loc here? *)
       
 and raw_line = 
   | Raw_line of loc * string
@@ -777,13 +766,6 @@ type raw_drule_line_annot =
     { dla_name : string;
       dla_categories : raw_ident list;
       dla_homs : raw_homomorphism list}
-
-let empty_raw_sd = 
-  { raw_sd_mds = []; raw_sd_rs = []; raw_sd_dcs = []; 
-    raw_sd_srs = []; raw_sd_crs = []; raw_sd_sbs = []; raw_sd_fvs = [];
-    raw_sd_embed = []; raw_sd_hss = [];
-    raw_sd_pas = [];
-    raw_sd_loc = dummy_loc } 
 
 
 

--- a/tests/menhir_tests/test_case_collision/Makefile
+++ b/tests/menhir_tests/test_case_collision/Makefile
@@ -1,0 +1,48 @@
+#  make -C ../.. && make clean && make
+
+ROOT            := test_case_collision
+
+OTTDIR          := ../../..
+
+OTT             := $(OTTDIR)/bin/ott
+
+MENHIR_EXTRA_LIB:= $(OTTDIR)/menhir/menhir_library_extra.mly
+
+MENHIR          := menhir
+
+MENHIRFLAGS     := --infer --base $(ROOT)_parser
+
+OCAMLBUILD      := ocamlbuild -use-ocamlfind -use-menhir -menhir "$(MENHIR) $(MENHIRFLAGS) ../$(MENHIR_EXTRA_LIB) " -package pprint
+
+MAIN            := main
+
+all: $(ROOT)_ast.ml $(ROOT)_parser.mly $(ROOT)_parser_pp.ml $(ROOT)_lexer.mll main.ml
+	$(OCAMLBUILD) $(MAIN).byte
+
+
+pdf: $(ROOT)_quotiented.pdf $(ROOT)_unquotiented.pdf
+
+# generate the ocaml AST type, ocamllex lexer, menhir parser, and ocaml pretty printers for the AST, all from the Ott soruce
+$(ROOT)_ast.ml  $(ROOT)_lexer.mll $(ROOT)_parser.mly $(ROOT)_parser_pp.ml $(ROOT)_ast.tex : $(ROOT).ott
+	$(OTT) -show_sort true -quotient_rules false -i $(ROOT).ott  -o $(ROOT)_parser.mly -o $(ROOT)_lexer.mll -o $(ROOT)_ast.ml -o $(ROOT).tex
+
+
+$(ROOT)_quotiented.pdf: $(ROOT).ott Makefile
+	$(OTT) -quotient_rules true -i $(ROOT).ott -o $(ROOT)_quotiented.tex
+	pdflatex $(ROOT)_quotiented.tex
+
+$(ROOT)_unquotiented.pdf: $(ROOT).ott Makefile
+	$(OTT) -quotient_rules false -i $(ROOT).ott -o $(ROOT)_unquotiented.tex
+	pdflatex $(ROOT)_unquotiented.tex
+
+clean:
+	rm -rf *~
+	rm -rf _build
+	rm -rf $(ROOT)_ast.ml $(ROOT)_parser.mly $(ROOT)_lexer.mll $(ROOT)_parser_pp.ml
+	rm -rf *.aux *.log *.tex
+	rm -rf main.native main.byte
+	$(OCAMLBUILD) -clean
+
+realclean:
+	$(MAKE) clean
+	rm -rf *.pdf

--- a/tests/menhir_tests/test_case_collision/main.ml
+++ b/tests/menhir_tests/test_case_collision/main.ml
@@ -1,0 +1,13 @@
+open Test_case_collision_ast
+
+module Lexer = Test_case_collision_lexer
+module Parser = Test_case_collision_parser
+module PP = Test_case_collision_parser_pp
+
+let _parse_ty : Lexing.lexbuf -> ty = Parser.ty_start Lexer.token
+
+let _pp_raw_ty : ty -> PPrint.document = PP.pp_raw_ty
+
+let _pp_ty : ty -> PPrint.document = PP.pp_ty
+
+let () = ()

--- a/tests/menhir_tests/test_case_collision/test_case_collision.ott
+++ b/tests/menhir_tests/test_case_collision/test_case_collision.ott
@@ -1,0 +1,13 @@
+indexvar index, i ::=
+  {{ rocq nat }}
+  {{ ocaml int }}
+
+grammar
+
+tag, T :: 'tag_' ::=
+  | x :: :: x
+
+ty, t :: 'ty_' ::= {{ menhir-start }}
+  | unit    :: :: unit
+  | sum T t :: :: sum
+  | sums ( </ Ti ti // i /> ) :: :: sums

--- a/tests/test_grammar_embed_1.ott
+++ b/tests/test_grammar_embed_1.ott
@@ -1,0 +1,13 @@
+indexvar x ::= {{coq nat}}
+
+grammar
+
+term, t :: 't_' ::=
+  | x            ::  :: var
+
+embed {{ coq
+
+Definition expr_ty := term. }}
+
+expr, e :: 'e_' ::= {{ coq expr_ty }}
+  | t            ::  :: term {{ coq [[t]] }}

--- a/tests/test_grammar_embed_2.ott
+++ b/tests/test_grammar_embed_2.ott
@@ -1,0 +1,13 @@
+indexvar x ::= {{ coq nat }}
+
+grammar
+
+expr, e :: 'e_' ::= {{ coq expr_ty }}
+  | foo t        ::  :: term {{ coq [[t]] }}
+
+term, t :: 't_' ::=
+  | x            ::  :: var
+
+embed {{ coq
+
+Definition expr_ty := term. }}

--- a/tests/test_grammar_embed_3.ott
+++ b/tests/test_grammar_embed_3.ott
@@ -1,0 +1,13 @@
+indexvar x ::= {{coq nat}}
+
+grammar
+
+term, t :: 't_' ::=
+  | e            ::  :: var
+
+embed {{ coq
+
+Definition expr_ty := term. }}
+
+expr, e :: 'e_' ::=
+  | x            ::  :: term

--- a/tests/test_grammar_embed_4.ott
+++ b/tests/test_grammar_embed_4.ott
@@ -1,0 +1,39 @@
+indexvar x ::= {{coq nat}}
+
+grammar
+
+term, t :: 't_' ::=
+  | e            ::  :: var
+
+expr, e :: 'e_' ::=
+  | x            ::  :: term
+
+formula :: formula_ ::=
+  | judgement             ::   :: judgement
+  | not ( formula )       ::   :: not
+    {{ coq is_not([[formula]]) }}
+  | bad e                 ::   :: bad
+    {{ coq is_bad([[e]]) }}
+
+embed {{ coq
+
+Definition is_not P := not P.
+}}
+
+terminals :: 'terminals_' ::=
+  | not                   ::   :: not  {{ tex \lnot }}
+
+embed {{ coq
+
+Definition is_bad (e : expr) := False.
+}}
+
+defns
+  Goodness :: '' ::=
+
+defn
+  |- t ::  :: Ok :: Ok  by
+
+  not(bad e)
+  ----------- :: E
+  |- e

--- a/tests/test_grammar_embed_grouped.ott
+++ b/tests/test_grammar_embed_grouped.ott
@@ -1,0 +1,14 @@
+indexvar x ::= {{coq nat}}
+
+grammar
+
+term, t :: 't_' ::=
+  | leaf x       ::  :: leaf
+  | box e        ::  :: expr
+embed {{ coq
+
+Definition grouped_expr_id (e : expr) := e.
+}}
+expr, e :: 'e_' ::=
+  | bare x       ::  :: var
+  | unbox t      ::  :: term

--- a/tests/test_grammar_embed_leading.ott
+++ b/tests/test_grammar_embed_leading.ott
@@ -1,0 +1,11 @@
+indexvar x ::= {{coq nat}}
+
+grammar
+
+embed {{ coq
+
+Definition leading_ty := nat.
+}}
+
+term, t :: 't_' ::= {{ coq leading_ty }}
+  | x                     ::   :: var

--- a/tests/test_grammar_embed_ocaml_rename.ott
+++ b/tests/test_grammar_embed_ocaml_rename.ott
@@ -1,0 +1,10 @@
+metavar typevar, X ::= {{ coq nat }} {{ ocaml int }}
+
+grammar
+
+Term :: 't_' ::=
+  | foo X        ::  :: foo
+embed {{ ocaml
+
+let attached_embed x = [[foo X]]
+}}

--- a/tests/test_grammar_embed_phantom_first.ott
+++ b/tests/test_grammar_embed_phantom_first.ott
@@ -1,0 +1,14 @@
+indexvar x ::= {{coq nat}}
+
+grammar
+
+formula :: formula_ ::=
+  | judgement             ::   :: judgement
+
+embed {{ coq
+
+Definition helper_ty := nat.
+}}
+
+term, t :: 't_' ::= {{ coq helper_ty }}
+  | x                     ::   :: var

--- a/tests/test_grammar_embed_phantom_only.ott
+++ b/tests/test_grammar_embed_phantom_only.ott
@@ -1,0 +1,29 @@
+indexvar x ::= {{coq nat}}
+
+grammar
+
+term, t :: 't_' ::=
+  | x                     ::   :: var
+
+terminals :: 'terminals_' ::=
+  | phantom_only          ::   :: phantom_only
+
+formula :: formula_ ::=
+  | judgement             ::   :: judgement
+  | phantom_only          ::   :: phantom_only
+    {{ coq phantom_only }}
+
+embed {{ coq
+
+Definition phantom_only : Prop := True.
+}}
+
+defns
+  Goodness :: '' ::=
+
+defn
+  |- t ::  :: Ok :: Ok  by
+
+  phantom_only
+  ----------- :: E
+  |- t

--- a/tests/test_grammar_embed_quotient.ott
+++ b/tests/test_grammar_embed_quotient.ott
@@ -1,0 +1,16 @@
+indexvar x ::= {{coq nat}}
+
+grammar
+
+term, t :: 't_' ::=
+  | x            ::  :: var
+
+expr, e :: 't_' ::= {{ quotient-with t }}
+  | box t        ::  :: lift
+embed {{ coq
+
+Definition quotient_ty := term.
+}}
+
+wrapper :: 'wrapper_' ::= {{ coq quotient_ty }}
+  | t            ::  :: wrapped

--- a/tests/test_grammar_embed_tex_interleave.ott
+++ b/tests/test_grammar_embed_tex_interleave.ott
@@ -1,0 +1,14 @@
+indexvar x ::= {{coq nat}}
+
+grammar
+
+term, t :: 't_' ::=
+  | x            ::  :: var
+
+embed {{ tex
+
+TEX_INTERLEAVE_MARKER
+}}
+
+expr, e :: 'e_' ::=
+  | t            ::  :: term


### PR DESCRIPTION
This just fixes a typo in `menhir/menhir_library_extra.mly`, which gets copied to the build directory as `menhir_extra.mly` in some circumstances when using the Menhir backend.

The typo prevents the parser from compiling when this file is included.